### PR TITLE
[Feat] 동물 정보 상세 조회 로직 구현

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/image/ReportImageRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/image/ReportImageRepository.java
@@ -1,0 +1,7 @@
+package com.kuit.findyou.domain.image;
+
+import com.kuit.findyou.domain.image.model.ReportImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportImageRepository extends JpaRepository<ReportImage, Long> {
+}

--- a/src/main/java/com/kuit/findyou/domain/image/model/ReportImage.java
+++ b/src/main/java/com/kuit/findyou/domain/image/model/ReportImage.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.util.List;
+
 @Entity
 @Table(name = "report_images")
 @Getter

--- a/src/main/java/com/kuit/findyou/domain/image/repository/ReportImageRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/image/repository/ReportImageRepository.java
@@ -1,4 +1,4 @@
-package com.kuit.findyou.domain.image;
+package com.kuit.findyou.domain.image.repository;
 
 import com.kuit.findyou.domain.image.model.ReportImage;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -4,7 +4,7 @@ import com.kuit.findyou.domain.report.dto.response.MissingReportDetailResponseDT
 import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.dto.response.WitnessReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.model.*;
-import com.kuit.findyou.domain.report.service.ReportDetailService;
+import com.kuit.findyou.domain.report.service.facade.ReportServiceFacade;
 import com.kuit.findyou.global.common.annotation.CustomExceptionDescription;
 import com.kuit.findyou.global.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,55 +18,42 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.*;
 
-@Tag(name = "Report", description = "글 조회 API")
 @RestController
 @Slf4j
 @RequestMapping("/api/v2/reports")
+@Tag(name = "Report", description = "글 조회 API")
 @RequiredArgsConstructor
 public class ReportController {
 
-    private final ReportDetailService reportDetailService;
+    private final ReportServiceFacade reportServiceFacade;
 
-    // todo userId 를 토큰으로부터 추출하는 로직 필요
-    @Operation(
-            summary = "보호글 상세 조회 API",
-            description = "보호글의 정보를 상세 조회하기 위한 API"
-    )
+    @Operation(summary = "보호글 상세 조회 API", description = "보호글의 정보를 상세 조회하기 위한 API")
     @GetMapping("/protecting/{reportId}")
     @CustomExceptionDescription(PROTECTING_REPORT_DETAIL)
     public BaseResponse<ProtectingReportDetailResponseDTO> getProtectingReportDetail(
             @PathVariable("reportId") Long reportId) {
 
-        ProtectingReportDetailResponseDTO detail = reportDetailService.getReportDetail(ReportTag.PROTECTING, reportId, 1L);
+        ProtectingReportDetailResponseDTO detail = reportServiceFacade.getReportDetail(ReportTag.PROTECTING, reportId, 1L);
         return BaseResponse.ok(detail);
     }
 
-    // todo userId 를 토큰으로부터 추출하는 로직 필요
-    @Operation(
-            summary = "실종 신고글 상세 조회 API",
-            description = "실종 신고글의 정보를 상세 조회하기 위한 API"
-    )
+    @Operation(summary = "실종 신고글 상세 조회 API", description = "실종 신고글의 정보를 상세 조회하기 위한 API")
     @GetMapping("/missing/{reportId}")
     @CustomExceptionDescription(MISSING_REPORT_DETAIL)
     public BaseResponse<MissingReportDetailResponseDTO> getMissingReportDetail(
             @PathVariable("reportId") Long reportId) {
 
-        MissingReportDetailResponseDTO detail = reportDetailService.getReportDetail(ReportTag.MISSING, reportId, 1L);
+        MissingReportDetailResponseDTO detail = reportServiceFacade.getReportDetail(ReportTag.MISSING, reportId, 1L);
         return BaseResponse.ok(detail);
     }
 
-    // todo userId 를 토큰으로부터 추출하는 로직 필요
-    @Operation(
-            summary = "목격 신고글 상세 조회 API",
-            description = "목격 신고글의 정보를 상세 조회하기 위한 API"
-    )
+    @Operation(summary = "목격 신고글 상세 조회 API", description = "목격 신고글의 정보를 상세 조회하기 위한 API")
     @GetMapping("/witness/{reportId}")
     @CustomExceptionDescription(WITNESS_REPORT_DETAIL)
     public BaseResponse<WitnessReportDetailResponseDTO> getWitnessReportDetail(
             @PathVariable("reportId") Long reportId) {
 
-        WitnessReportDetailResponseDTO detail = reportDetailService.getReportDetail(ReportTag.WITNESS, reportId, 1L);
+        WitnessReportDetailResponseDTO detail = reportServiceFacade.getReportDetail(ReportTag.WITNESS, reportId, 1L);
         return BaseResponse.ok(detail);
     }
-
 }

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -5,13 +5,17 @@ import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailRespons
 import com.kuit.findyou.domain.report.dto.response.WitnessReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.model.ReportTag;
 import com.kuit.findyou.domain.report.service.ReportDetailService;
+import com.kuit.findyou.global.common.annotation.CustomExceptionDescription;
 import com.kuit.findyou.global.common.response.BaseResponse;
+import com.kuit.findyou.global.common.swagger.SwaggerResponseDescription;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.*;
 
 @RestController
 @Slf4j
@@ -23,6 +27,7 @@ public class ReportController {
 
     // todo userId 를 토큰으로부터 추출하는 로직 필요
     @GetMapping("/protecting/{reportId}")
+    @CustomExceptionDescription(PROTECTING_REPORT_DETAIL)
     public BaseResponse<ProtectingReportDetailResponseDTO> getProtectingReportDetail(
             @PathVariable("reportId") Long reportId) {
 
@@ -33,6 +38,7 @@ public class ReportController {
 
     // todo userId 를 토큰으로부터 추출하는 로직 필요
     @GetMapping("/missing/{reportId}")
+    @CustomExceptionDescription(MISSING_REPORT_DETAIL)
     public BaseResponse<MissingReportDetailResponseDTO> getMissingReportDetail(
             @PathVariable("reportId") Long reportId) {
 
@@ -42,6 +48,7 @@ public class ReportController {
 
     // todo userId 를 토큰으로부터 추출하는 로직 필요
     @GetMapping("/witness/{reportId}")
+    @CustomExceptionDescription(WITNESS_REPORT_DETAIL)
     public BaseResponse<WitnessReportDetailResponseDTO> getWitnessReportDetail(
             @PathVariable("reportId") Long reportId) {
 

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -1,0 +1,51 @@
+package com.kuit.findyou.domain.report.controller;
+
+import com.kuit.findyou.domain.report.dto.response.MissingReportDetailResponseDTO;
+import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailResponseDTO;
+import com.kuit.findyou.domain.report.dto.response.WitnessReportDetailResponseDTO;
+import com.kuit.findyou.domain.report.model.ReportTag;
+import com.kuit.findyou.domain.report.service.ReportDetailService;
+import com.kuit.findyou.global.common.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequestMapping("/api/v2/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportDetailService reportDetailService;
+
+    // todo userId 를 토큰으로부터 추출하는 로직 필요
+    @GetMapping("/protecting/{reportId}")
+    public BaseResponse<ProtectingReportDetailResponseDTO> getProtectingReportDetail(
+            @PathVariable("reportId") Long reportId) {
+
+
+        ProtectingReportDetailResponseDTO detail = reportDetailService.getReportDetail(ReportTag.PROTECTING, reportId, 1L);
+        return BaseResponse.ok(detail);
+    }
+
+    // todo userId 를 토큰으로부터 추출하는 로직 필요
+    @GetMapping("/missing/{reportId}")
+    public BaseResponse<MissingReportDetailResponseDTO> getMissingReportDetail(
+            @PathVariable("reportId") Long reportId) {
+
+        MissingReportDetailResponseDTO detail = reportDetailService.getReportDetail(ReportTag.MISSING, reportId, 1L);
+        return BaseResponse.ok(detail);
+    }
+
+    // todo userId 를 토큰으로부터 추출하는 로직 필요
+    @GetMapping("/witness/{reportId}")
+    public BaseResponse<WitnessReportDetailResponseDTO> getWitnessReportDetail(
+            @PathVariable("reportId") Long reportId) {
+
+        WitnessReportDetailResponseDTO detail = reportDetailService.getReportDetail(ReportTag.WITNESS, reportId, 1L);
+        return BaseResponse.ok(detail);
+    }
+}

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -7,6 +7,8 @@ import com.kuit.findyou.domain.report.model.*;
 import com.kuit.findyou.domain.report.service.ReportDetailService;
 import com.kuit.findyou.global.common.annotation.CustomExceptionDescription;
 import com.kuit.findyou.global.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.*;
 
+@Tag(name = "Report", description = "글 조회 API")
 @RestController
 @Slf4j
 @RequestMapping("/api/v2/reports")
@@ -25,6 +28,10 @@ public class ReportController {
     private final ReportDetailService reportDetailService;
 
     // todo userId 를 토큰으로부터 추출하는 로직 필요
+    @Operation(
+            summary = "보호글 상세 조회 API",
+            description = "보호글의 정보를 상세 조회하기 위한 API"
+    )
     @GetMapping("/protecting/{reportId}")
     @CustomExceptionDescription(PROTECTING_REPORT_DETAIL)
     public BaseResponse<ProtectingReportDetailResponseDTO> getProtectingReportDetail(
@@ -35,6 +42,10 @@ public class ReportController {
     }
 
     // todo userId 를 토큰으로부터 추출하는 로직 필요
+    @Operation(
+            summary = "실종 신고글 상세 조회 API",
+            description = "실종 신고글의 정보를 상세 조회하기 위한 API"
+    )
     @GetMapping("/missing/{reportId}")
     @CustomExceptionDescription(MISSING_REPORT_DETAIL)
     public BaseResponse<MissingReportDetailResponseDTO> getMissingReportDetail(
@@ -45,6 +56,10 @@ public class ReportController {
     }
 
     // todo userId 를 토큰으로부터 추출하는 로직 필요
+    @Operation(
+            summary = "목격 신고글 상세 조회 API",
+            description = "목격 신고글의 정보를 상세 조회하기 위한 API"
+    )
     @GetMapping("/witness/{reportId}")
     @CustomExceptionDescription(WITNESS_REPORT_DETAIL)
     public BaseResponse<WitnessReportDetailResponseDTO> getWitnessReportDetail(

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -3,11 +3,10 @@ package com.kuit.findyou.domain.report.controller;
 import com.kuit.findyou.domain.report.dto.response.MissingReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.dto.response.WitnessReportDetailResponseDTO;
-import com.kuit.findyou.domain.report.model.ReportTag;
+import com.kuit.findyou.domain.report.model.*;
 import com.kuit.findyou.domain.report.service.ReportDetailService;
 import com.kuit.findyou.global.common.annotation.CustomExceptionDescription;
 import com.kuit.findyou.global.common.response.BaseResponse;
-import com.kuit.findyou.global.common.swagger.SwaggerResponseDescription;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,7 +29,6 @@ public class ReportController {
     @CustomExceptionDescription(PROTECTING_REPORT_DETAIL)
     public BaseResponse<ProtectingReportDetailResponseDTO> getProtectingReportDetail(
             @PathVariable("reportId") Long reportId) {
-
 
         ProtectingReportDetailResponseDTO detail = reportDetailService.getReportDetail(ReportTag.PROTECTING, reportId, 1L);
         return BaseResponse.ok(detail);
@@ -55,4 +53,5 @@ public class ReportController {
         WitnessReportDetailResponseDTO detail = reportDetailService.getReportDetail(ReportTag.WITNESS, reportId, 1L);
         return BaseResponse.ok(detail);
     }
+
 }

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/MissingReportDetailResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/MissingReportDetailResponseDTO.java
@@ -17,7 +17,8 @@ public record MissingReportDetailResponseDTO(
         String missingAddress,
         double latitude,
         double longitude,
-        String reporterInfo,
+        String reporterName,
+        String reporterTel,
         boolean interest
 ) {
 }

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/MissingReportDetailResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/MissingReportDetailResponseDTO.java
@@ -1,5 +1,7 @@
 package com.kuit.findyou.domain.report.dto.response;
 
+import lombok.Builder;
+
 import java.util.List;
 
 public record MissingReportDetailResponseDTO(

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/MissingReportDetailResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/MissingReportDetailResponseDTO.java
@@ -1,24 +1,53 @@
 package com.kuit.findyou.domain.report.dto.response;
 
-import lombok.Builder;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
 public record MissingReportDetailResponseDTO(
+        @Schema(description = "실종 신고 이미지 URL 목록", example = "[\"https://example.com/missing1.jpg\", \"https://example.com/missing2.jpg\"]")
         List<String> imageUrls,
+
+        @Schema(description = "품종", example = "웰시코기")
         String breed,
+
+        @Schema(description = "태그", example = "실종신고")
         String tag,
+
+        @Schema(description = "나이", example = "1살")
         String age,
+
+        @Schema(description = "성별", example = "수컷")
         String sex,
+
+        @Schema(description = "실종 날짜", example = "2024-01-15")
         String missingDate,
+
+        @Schema(description = "RFID 번호", example = "RFID123456")
         String rfid,
+
+        @Schema(description = "특징", example = "나비라는 이름의 귀여운 웰시코기입니다")
         String significant,
+
+        @Schema(description = "실종 장소", example = "서초역 1번 출구")
         String missingLocation,
+
+        @Schema(description = "실종 주소", example = "서울시 서초구 서초대로 789")
         String missingAddress,
+
+        @Schema(description = "위도", example = "37.491916")
         double latitude,
+
+        @Schema(description = "경도", example = "127.007912")
         double longitude,
+
+        @Schema(description = "신고자 이름", example = "김철수")
         String reporterName,
+
+        @Schema(description = "신고자 연락처", example = "010-1234-5678")
         String reporterTel,
+
+        @Schema(description = "관심글 여부", example = "true")
         boolean interest
 ) {
 }

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/MissingReportDetailResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/MissingReportDetailResponseDTO.java
@@ -1,0 +1,21 @@
+package com.kuit.findyou.domain.report.dto.response;
+
+import java.util.List;
+
+public record MissingReportDetailResponseDTO(
+        List<String> imageUrls,
+        String breed,
+        String tag,
+        String age,
+        String sex,
+        String missingDate,
+        String rfid,
+        String significant,
+        String missingLocation,
+        String missingAddress,
+        double latitude,
+        double longitude,
+        String reporterInfo,
+        boolean interest
+) {
+}

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/ProtectingReportDetailResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/ProtectingReportDetailResponseDTO.java
@@ -1,30 +1,70 @@
 package com.kuit.findyou.domain.report.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.util.List;
 
 @Builder
 public record ProtectingReportDetailResponseDTO(
+        @Schema(description = "보호 신고 이미지 URL 목록", example = "[\"https://example.com/protecting1.jpg\", \"https://example.com/protecting2.jpg\"]")
         List<String> imageUrls,
+
+        @Schema(description = "품종", example = "골든 리트리버")
         String breed,
+
+        @Schema(description = "태그", example = "보호중")
         String tag,
+
+        @Schema(description = "나이", example = "3살")
         String age,
+
+        @Schema(description = "체중", example = "25kg")
         String weight,
+
+        @Schema(description = "털색", example = "황금색")
         String furColor,
+
+        @Schema(description = "성별", example = "수컷")
         String sex,
+
+        @Schema(description = "중성화 여부", example = "Y")
         String neutering,
+
+        @Schema(description = "특징", example = "귀여운 골든 리트리버입니다")
         String significant,
+
+        @Schema(description = "보호소 이름", example = "강남동물보호소")
         String careName,
+
+        @Schema(description = "보호소 주소", example = "서울시 강남구 보호소로 456")
         String careAddr,
+
+        @Schema(description = "위도", example = "37.566512")
         double latitude,
+
+        @Schema(description = "경도", example = "126.978006")
         double longitude,
+
+        @Schema(description = "보호소 연락처", example = "02-1234-5678")
         String careTel,
+
+        @Schema(description = "발견 날짜", example = "2024-01-10")
         String foundDate,
+
+        @Schema(description = "발견 장소", example = "강남역 근처")
         String foundLocation,
+
+        @Schema(description = "공고 기간", example = "2024-01-10 ~ 2024-01-20")
         String noticeDuration,
+
+        @Schema(description = "공고 번호", example = "2024-001123132")
         String noticeNumber,
+
+        @Schema(description = "관할 기관", example = "서울시 강남구청")
         String authority,
+
+        @Schema(description = "관심글 여부", example = "true")
         boolean interest
 ) {
 }

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/ProtectingReportDetailResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/ProtectingReportDetailResponseDTO.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 @Builder
 public record ProtectingReportDetailResponseDTO(
-        List<String> imageUrl,
+        List<String> imageUrls,
         String breed,
         String tag,
         String age,

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/ProtectingReportDetailResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/ProtectingReportDetailResponseDTO.java
@@ -1,0 +1,27 @@
+package com.kuit.findyou.domain.report.dto.response;
+
+import java.util.List;
+
+public record ProtectingReportDetailResponseDTO(
+        List<String> imageUrl,
+        String breed,
+        String tag,
+        String age,
+        String weight,
+        String furColor,
+        String sex,
+        String neutering,
+        String significant,
+        String careName,
+        String careAddr,
+        double latitude,
+        double longitude,
+        String careTel,
+        String foundDate,
+        String foundLocation,
+        String noticeDuration,
+        String noticeNumber,
+        String authority,
+        boolean interest
+) {
+}

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/ProtectingReportDetailResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/ProtectingReportDetailResponseDTO.java
@@ -1,7 +1,10 @@
 package com.kuit.findyou.domain.report.dto.response;
 
+import lombok.Builder;
+
 import java.util.List;
 
+@Builder
 public record ProtectingReportDetailResponseDTO(
         List<String> imageUrl,
         String breed,

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/ProtectingReportDetailResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/ProtectingReportDetailResponseDTO.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 
 import java.util.List;
 
-@Builder
 public record ProtectingReportDetailResponseDTO(
         @Schema(description = "보호 신고 이미지 URL 목록", example = "[\"https://example.com/protecting1.jpg\", \"https://example.com/protecting2.jpg\"]")
         List<String> imageUrls,

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/WitnessReportDetailResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/WitnessReportDetailResponseDTO.java
@@ -1,22 +1,43 @@
 package com.kuit.findyou.domain.report.dto.response;
 
-import lombok.Builder;
-
-import java.util.ArrayList;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record WitnessReportDetailResponseDTO(
+        @Schema(description = "목격 신고 이미지 URL 목록", example = "[\"https://example.com/witness1.jpg\"]")
         List<String> imageUrls,
+
+        @Schema(description = "품종", example = "믹스견")
         String breed,
+
+        @Schema(description = "태그", example = "목격신고")
         String tag,
+
+        @Schema(description = "털색", example = "흰색")
         String furColor,
+
+        @Schema(description = "특징", example = "공원에서 혼자 돌아다니는 강아지를 봤습니다")
         String significant,
+
+        @Schema(description = "목격 장소", example = "홍대입구역 2번 출구")
         String witnessLocation,
+
+        @Schema(description = "목격 주소", example = "서울시 마포구 홍대로 321")
         String witnessAddress,
+
+        @Schema(description = "위도", example = "37.557112")
         double latitude,
+
+        @Schema(description = "경도", example = "126.925643")
         double longitude,
+
+        @Schema(description = "신고자 정보", example = "이영희")
         String reporterInfo,
+
+        @Schema(description = "목격 날짜", example = "2024-01-14")
         String witnessDate,
+
+        @Schema(description = "관심글 여부", example = "true")
         boolean interest
 ) {
 }

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/WitnessReportDetailResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/WitnessReportDetailResponseDTO.java
@@ -1,0 +1,19 @@
+package com.kuit.findyou.domain.report.dto.response;
+
+import java.util.List;
+
+public record WitnessReportDetailResponseDTO(
+        List<String> imageUrls,
+        String breed,
+        String tag,
+        String furColor,
+        String significant,
+        String witnessLocation,
+        String witnessAddress,
+        double latitude,
+        double longitude,
+        String reporterInfo,
+        String witnessDate,
+        boolean interest
+) {
+}

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/WitnessReportDetailResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/WitnessReportDetailResponseDTO.java
@@ -1,5 +1,8 @@
 package com.kuit.findyou.domain.report.dto.response;
 
+import lombok.Builder;
+
+import java.util.ArrayList;
 import java.util.List;
 
 public record WitnessReportDetailResponseDTO(

--- a/src/main/java/com/kuit/findyou/domain/report/model/MissingReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/MissingReport.java
@@ -40,7 +40,6 @@ public class MissingReport extends Report {
     @Column(name = "reporter_tel", length = 20)
     private String reporterTel;
 
-
     @Column(name = "landmark", nullable = false)
     private String landmark;
 

--- a/src/main/java/com/kuit/findyou/domain/report/model/ProtectingReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/ProtectingReport.java
@@ -1,5 +1,6 @@
 package com.kuit.findyou.domain.report.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.kuit.findyou.domain.user.model.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -128,6 +129,12 @@ public class ProtectingReport extends Report {
 
         return report;
     }
+
+    @JsonIgnore
+    public String getNoticeDuration() {
+        return noticeStartDate + " ~ " + noticeEndDate;
+    }
+
 }
 
 

--- a/src/main/java/com/kuit/findyou/domain/report/model/Report.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/Report.java
@@ -1,8 +1,10 @@
 package com.kuit.findyou.domain.report.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.kuit.findyou.domain.image.model.ReportImage;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.global.common.model.BaseEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -74,5 +76,10 @@ public abstract class Report extends BaseEntity {
         interestReports.add(interestReport);
     }
 
-
+    @JsonIgnore
+    public List<String> getReportImagesUrlList() {
+        return reportImages.stream()
+                .map(ReportImage::getImageUrl)
+                .toList();
+    }
 }

--- a/src/main/java/com/kuit/findyou/domain/report/repository/InterestReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/InterestReportRepository.java
@@ -1,0 +1,11 @@
+package com.kuit.findyou.domain.report.repository;
+
+
+import com.kuit.findyou.domain.report.model.InterestReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterestReportRepository extends JpaRepository<InterestReport, Long> {
+
+    boolean existsByReport_IdAndUser_Id(Long reportId, Long userId);
+
+}

--- a/src/main/java/com/kuit/findyou/domain/report/repository/MissingReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/MissingReportRepository.java
@@ -1,10 +1,17 @@
 package com.kuit.findyou.domain.report.repository;
 
 import com.kuit.findyou.domain.report.model.MissingReport;
+import com.kuit.findyou.domain.report.model.ProtectingReport;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 
 @Repository
 public interface MissingReportRepository extends JpaRepository<MissingReport, Long> {
+
+    @EntityGraph(attributePaths = {"reportImages"})
+    Optional<MissingReport> findWithImagesById(Long id);
 }

--- a/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
@@ -1,10 +1,16 @@
 package com.kuit.findyou.domain.report.repository;
 
 import com.kuit.findyou.domain.report.model.ProtectingReport;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ProtectingReportRepository extends JpaRepository<ProtectingReport, Long> {
+
+    @EntityGraph(attributePaths = {"reportImages"})
+    Optional<ProtectingReport> findWithImagesById(Long id);
 }
 

--- a/src/main/java/com/kuit/findyou/domain/report/repository/WitnessReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/WitnessReportRepository.java
@@ -1,10 +1,17 @@
 package com.kuit.findyou.domain.report.repository;
 
+import com.kuit.findyou.domain.report.model.ProtectingReport;
 import com.kuit.findyou.domain.report.model.WitnessReport;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface WitnessReportRepository extends JpaRepository<WitnessReport, Long> {
+
+    @EntityGraph(attributePaths = {"reportImages"})
+    Optional<WitnessReport> findWithImagesById(Long id);
 }
 

--- a/src/main/java/com/kuit/findyou/domain/report/service/ReportDetailService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/ReportDetailService.java
@@ -44,11 +44,11 @@ public class ReportDetailService {
 
     private Report findReportByTagAndId(ReportTag tag, Long reportId) {
         return switch (tag) {
-            case PROTECTING -> protectingReportRepository.findById(reportId)
+            case PROTECTING -> protectingReportRepository.findWithImagesById(reportId)
                     .orElseThrow(() -> new CustomException(PROTECTING_REPORT_NOT_FOUND));
-            case MISSING -> missingReportRepository.findById(reportId)
+            case MISSING -> missingReportRepository.findWithImagesById(reportId)
                     .orElseThrow(() -> new CustomException(MISSING_REPORT_NOT_FOUND));
-            case WITNESS -> witnessReportRepository.findById(reportId)
+            case WITNESS -> witnessReportRepository.findWithImagesById(reportId)
                     .orElseThrow(() -> new CustomException(WITNESS_REPORT_NOT_FOUND));
             default -> throw new CustomException(ILLEGAL_TAG);
         };

--- a/src/main/java/com/kuit/findyou/domain/report/service/ReportDetailService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/ReportDetailService.java
@@ -1,0 +1,56 @@
+package com.kuit.findyou.domain.report.service;
+
+
+import com.kuit.findyou.domain.report.model.Report;
+import com.kuit.findyou.domain.report.model.ReportTag;
+import com.kuit.findyou.domain.report.repository.InterestReportRepository;
+import com.kuit.findyou.domain.report.repository.MissingReportRepository;
+import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
+import com.kuit.findyou.domain.report.repository.WitnessReportRepository;
+import com.kuit.findyou.domain.report.strategy.ReportDetailStrategy;
+import com.kuit.findyou.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
+
+@Service
+@RequiredArgsConstructor
+public class ReportDetailService {
+
+    private final ProtectingReportRepository protectingReportRepository;
+    private final MissingReportRepository missingReportRepository;
+    private final WitnessReportRepository witnessReportRepository;
+
+    private final InterestReportRepository interestReportRepository;
+
+    private final Map<String, ReportDetailStrategy<? extends Report, ?>> strategies;
+
+    @SuppressWarnings("unchecked")
+    public <T> T getReportDetail(ReportTag tag, Long reportId, Long userId) {
+        ReportDetailStrategy<Report, T> strategy =  (ReportDetailStrategy<Report, T>) strategies.get(tag.toString());
+
+        if (strategy == null) {
+            throw new CustomException(ILLEGAL_TAG);
+        }
+
+        Report report = findReportByTagAndId(tag, reportId);
+        boolean interest = interestReportRepository.existsByReport_IdAndUser_Id(report.getId(), userId);
+
+        return strategy.getDetail(report, interest);
+    }
+
+    private Report findReportByTagAndId(ReportTag tag, Long reportId) {
+        return switch (tag) {
+            case PROTECTING -> protectingReportRepository.findById(reportId)
+                    .orElseThrow(() -> new CustomException(PROTECTING_REPORT_NOT_FOUND));
+            case MISSING -> missingReportRepository.findById(reportId)
+                    .orElseThrow(() -> new CustomException(MISSING_REPORT_NOT_FOUND));
+            case WITNESS -> witnessReportRepository.findById(reportId)
+                    .orElseThrow(() -> new CustomException(WITNESS_REPORT_NOT_FOUND));
+            default -> throw new CustomException(ILLEGAL_TAG);
+        };
+    }
+}

--- a/src/main/java/com/kuit/findyou/domain/report/service/ReportDetailService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/ReportDetailService.java
@@ -4,9 +4,6 @@ package com.kuit.findyou.domain.report.service;
 import com.kuit.findyou.domain.report.model.Report;
 import com.kuit.findyou.domain.report.model.ReportTag;
 import com.kuit.findyou.domain.report.repository.InterestReportRepository;
-import com.kuit.findyou.domain.report.repository.MissingReportRepository;
-import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
-import com.kuit.findyou.domain.report.repository.WitnessReportRepository;
 import com.kuit.findyou.domain.report.strategy.ReportDetailStrategy;
 import com.kuit.findyou.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -20,37 +17,22 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 @RequiredArgsConstructor
 public class ReportDetailService {
 
-    private final ProtectingReportRepository protectingReportRepository;
-    private final MissingReportRepository missingReportRepository;
-    private final WitnessReportRepository witnessReportRepository;
-
     private final InterestReportRepository interestReportRepository;
 
     private final Map<String, ReportDetailStrategy<? extends Report, ?>> strategies;
 
     @SuppressWarnings("unchecked")
-    public <T> T getReportDetail(ReportTag tag, Long reportId, Long userId) {
-        ReportDetailStrategy<Report, T> strategy =  (ReportDetailStrategy<Report, T>) strategies.get(tag.toString());
+    public <REPORT_TYPE extends Report, DTO_TYPE> DTO_TYPE getReportDetail(ReportTag tag, Long reportId, Long userId) {
+        ReportDetailStrategy<REPORT_TYPE, DTO_TYPE> strategy =  (ReportDetailStrategy<REPORT_TYPE, DTO_TYPE>) strategies.get(tag.toString());
 
         if (strategy == null) {
             throw new CustomException(ILLEGAL_TAG);
         }
 
-        Report report = findReportByTagAndId(tag, reportId);
+        REPORT_TYPE report = strategy.getReport(reportId);
         boolean interest = interestReportRepository.existsByReport_IdAndUser_Id(report.getId(), userId);
 
         return strategy.getDetail(report, interest);
     }
 
-    private Report findReportByTagAndId(ReportTag tag, Long reportId) {
-        return switch (tag) {
-            case PROTECTING -> protectingReportRepository.findWithImagesById(reportId)
-                    .orElseThrow(() -> new CustomException(PROTECTING_REPORT_NOT_FOUND));
-            case MISSING -> missingReportRepository.findWithImagesById(reportId)
-                    .orElseThrow(() -> new CustomException(MISSING_REPORT_NOT_FOUND));
-            case WITNESS -> witnessReportRepository.findWithImagesById(reportId)
-                    .orElseThrow(() -> new CustomException(WITNESS_REPORT_NOT_FOUND));
-            default -> throw new CustomException(ILLEGAL_TAG);
-        };
-    }
 }

--- a/src/main/java/com/kuit/findyou/domain/report/service/ReportDetailService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/ReportDetailService.java
@@ -5,6 +5,7 @@ import com.kuit.findyou.domain.report.model.Report;
 import com.kuit.findyou.domain.report.model.ReportTag;
 import com.kuit.findyou.domain.report.repository.InterestReportRepository;
 import com.kuit.findyou.domain.report.strategy.ReportDetailStrategy;
+import com.kuit.findyou.domain.user.repository.UserRepository;
 import com.kuit.findyou.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,11 +19,17 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 public class ReportDetailService {
 
     private final InterestReportRepository interestReportRepository;
+    private final UserRepository userRepository;
 
     private final Map<String, ReportDetailStrategy<? extends Report, ?>> strategies;
 
     @SuppressWarnings("unchecked")
     public <REPORT_TYPE extends Report, DTO_TYPE> DTO_TYPE getReportDetail(ReportTag tag, Long reportId, Long userId) {
+
+        if(!userRepository.existsById(userId)) {
+            throw new CustomException(USER_NOT_FOUND);
+        }
+
         ReportDetailStrategy<REPORT_TYPE, DTO_TYPE> strategy =  (ReportDetailStrategy<REPORT_TYPE, DTO_TYPE>) strategies.get(tag.toString());
 
         if (strategy == null) {

--- a/src/main/java/com/kuit/findyou/domain/report/service/detail/ReportDetailService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/detail/ReportDetailService.java
@@ -1,0 +1,9 @@
+package com.kuit.findyou.domain.report.service.detail;
+
+import com.kuit.findyou.domain.report.model.Report;
+import com.kuit.findyou.domain.report.model.ReportTag;
+
+public interface ReportDetailService {
+
+    <REPORT_TYPE extends Report, DTO_TYPE> DTO_TYPE getReportDetail(ReportTag tag, Long reportId, Long userId);
+}

--- a/src/main/java/com/kuit/findyou/domain/report/service/detail/ReportDetailServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/detail/ReportDetailServiceImpl.java
@@ -1,11 +1,10 @@
-package com.kuit.findyou.domain.report.service;
+package com.kuit.findyou.domain.report.service.detail;
 
 
 import com.kuit.findyou.domain.report.model.Report;
 import com.kuit.findyou.domain.report.model.ReportTag;
 import com.kuit.findyou.domain.report.repository.InterestReportRepository;
 import com.kuit.findyou.domain.report.strategy.ReportDetailStrategy;
-import com.kuit.findyou.domain.user.repository.UserRepository;
 import com.kuit.findyou.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,19 +15,14 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 
 @Service
 @RequiredArgsConstructor
-public class ReportDetailService {
+public class ReportDetailServiceImpl implements ReportDetailService {
 
     private final InterestReportRepository interestReportRepository;
-    private final UserRepository userRepository;
 
     private final Map<String, ReportDetailStrategy<? extends Report, ?>> strategies;
 
     @SuppressWarnings("unchecked")
     public <REPORT_TYPE extends Report, DTO_TYPE> DTO_TYPE getReportDetail(ReportTag tag, Long reportId, Long userId) {
-
-        if(!userRepository.existsById(userId)) {
-            throw new CustomException(USER_NOT_FOUND);
-        }
 
         ReportDetailStrategy<REPORT_TYPE, DTO_TYPE> strategy =  (ReportDetailStrategy<REPORT_TYPE, DTO_TYPE>) strategies.get(tag.toString());
 

--- a/src/main/java/com/kuit/findyou/domain/report/service/detail/ReportDetailServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/detail/ReportDetailServiceImpl.java
@@ -11,29 +11,22 @@ import org.springframework.stereotype.Service;
 
 import java.util.Map;
 
-import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
-
 @Service
 @RequiredArgsConstructor
 public class ReportDetailServiceImpl implements ReportDetailService {
 
     private final InterestReportRepository interestReportRepository;
+    private final Map<ReportTag, ReportDetailStrategy<? extends Report, ?>> strategies;
 
-    private final Map<String, ReportDetailStrategy<? extends Report, ?>> strategies;
-
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked")  // 전략 매핑은 안전하게 구성되어 있음 (ReportDetailStrategyConfig 참고)
     public <REPORT_TYPE extends Report, DTO_TYPE> DTO_TYPE getReportDetail(ReportTag tag, Long reportId, Long userId) {
-
-        ReportDetailStrategy<REPORT_TYPE, DTO_TYPE> strategy =  (ReportDetailStrategy<REPORT_TYPE, DTO_TYPE>) strategies.get(tag.toString());
-
-        if (strategy == null) {
-            throw new CustomException(ILLEGAL_TAG);
-        }
+        ReportDetailStrategy<REPORT_TYPE, DTO_TYPE> strategy =
+                (ReportDetailStrategy<REPORT_TYPE, DTO_TYPE>) strategies.get(tag);
 
         REPORT_TYPE report = strategy.getReport(reportId);
         boolean interest = interestReportRepository.existsByReport_IdAndUser_Id(report.getId(), userId);
 
         return strategy.getDetail(report, interest);
     }
-
 }
+

--- a/src/main/java/com/kuit/findyou/domain/report/service/facade/ReportServiceFacade.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/facade/ReportServiceFacade.java
@@ -1,9 +1,28 @@
 package com.kuit.findyou.domain.report.service.facade;
 
+import com.kuit.findyou.domain.report.model.ReportTag;
+import com.kuit.findyou.domain.report.service.detail.ReportDetailService;
+import com.kuit.findyou.domain.user.repository.UserRepository;
+import com.kuit.findyou.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
+
 @Service
 @RequiredArgsConstructor
-public class ReportService {
+public class ReportServiceFacade {
+
+    private final ReportDetailService reportDetailService;
+    private final UserRepository userRepository;
+
+    public <DTO_TYPE> DTO_TYPE getReportDetail(ReportTag tag, Long reportId, Long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new CustomException(USER_NOT_FOUND);
+        }
+
+        return reportDetailService.getReportDetail(tag, reportId, userId);
+    }
 }
+
+

--- a/src/main/java/com/kuit/findyou/domain/report/service/facade/ReportServiceFacade.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/facade/ReportServiceFacade.java
@@ -1,0 +1,9 @@
+package com.kuit.findyou.domain.report.service.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+}

--- a/src/main/java/com/kuit/findyou/domain/report/strategy/MissingReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/strategy/MissingReportDetailStrategy.java
@@ -2,10 +2,18 @@ package com.kuit.findyou.domain.report.strategy;
 
 import com.kuit.findyou.domain.report.dto.response.MissingReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.model.MissingReport;
+import com.kuit.findyou.domain.report.repository.MissingReportRepository;
+import com.kuit.findyou.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.MISSING_REPORT_NOT_FOUND;
+
+@RequiredArgsConstructor
 @Component("MISSING")
 public class MissingReportDetailStrategy implements ReportDetailStrategy<MissingReport, MissingReportDetailResponseDTO> {
+
+    private final MissingReportRepository missingReportRepository;
 
     @Override
     public MissingReportDetailResponseDTO getDetail(MissingReport report, boolean interest) {
@@ -26,6 +34,12 @@ public class MissingReportDetailStrategy implements ReportDetailStrategy<Missing
                 report.getReporterTel(),
                 interest
         );
+    }
+
+    @Override
+    public MissingReport getReport(Long reportId) {
+        return missingReportRepository.findWithImagesById(reportId)
+                .orElseThrow(() -> new CustomException(MISSING_REPORT_NOT_FOUND));
     }
 }
 

--- a/src/main/java/com/kuit/findyou/domain/report/strategy/MissingReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/strategy/MissingReportDetailStrategy.java
@@ -1,0 +1,31 @@
+package com.kuit.findyou.domain.report.strategy;
+
+import com.kuit.findyou.domain.report.dto.response.MissingReportDetailResponseDTO;
+import com.kuit.findyou.domain.report.model.MissingReport;
+import org.springframework.stereotype.Component;
+
+@Component("MISSING")
+public class MissingReportDetailStrategy implements ReportDetailStrategy<MissingReport, MissingReportDetailResponseDTO> {
+
+    @Override
+    public MissingReportDetailResponseDTO getDetail(MissingReport report, boolean interest) {
+        return new MissingReportDetailResponseDTO(
+                report.getReportImagesUrlList(),
+                report.getBreed(),
+                report.getTag().getValue(),
+                report.getAge(),
+                report.getSex().getValue(),
+                report.getDate().toString(),
+                report.getRfid(),
+                report.getSignificant(),
+                report.getLandmark(),       // missingLocation
+                report.getAddress(),        // missingAddress
+                report.getLatitude().doubleValue(),
+                report.getLongitude().doubleValue(),
+                report.getReporterName(),
+                report.getReporterTel(),
+                interest
+        );
+    }
+}
+

--- a/src/main/java/com/kuit/findyou/domain/report/strategy/MissingReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/strategy/MissingReportDetailStrategy.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.MISSING_REPORT_NOT_FOUND;
 
 @RequiredArgsConstructor
-@Component("MISSING")
+@Component
 public class MissingReportDetailStrategy implements ReportDetailStrategy<MissingReport, MissingReportDetailResponseDTO> {
 
     private final MissingReportRepository missingReportRepository;

--- a/src/main/java/com/kuit/findyou/domain/report/strategy/ProtectingReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/strategy/ProtectingReportDetailStrategy.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.PROTECTING_REPORT_NOT_FOUND;
 
 @RequiredArgsConstructor
-@Component("PROTECTING")
+@Component
 public class ProtectingReportDetailStrategy implements ReportDetailStrategy<ProtectingReport, ProtectingReportDetailResponseDTO> {
 
     private final ProtectingReportRepository protectingReportRepository;

--- a/src/main/java/com/kuit/findyou/domain/report/strategy/ProtectingReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/strategy/ProtectingReportDetailStrategy.java
@@ -1,0 +1,36 @@
+package com.kuit.findyou.domain.report.strategy;
+
+import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailResponseDTO;
+import com.kuit.findyou.domain.report.model.ProtectingReport;
+import com.kuit.findyou.domain.report.model.Report;
+import org.springframework.stereotype.Component;
+
+@Component("PROTECTING")
+public class ProtectingReportDetailStrategy implements ReportDetailStrategy<ProtectingReport, ProtectingReportDetailResponseDTO> {
+
+    @Override
+    public ProtectingReportDetailResponseDTO getDetail(ProtectingReport report, boolean interest) {
+        return new ProtectingReportDetailResponseDTO(
+                report.getReportImagesUrlList(),
+                report.getBreed(),
+                report.getTag().getValue(),
+                report.getAge(),
+                report.getWeight(),
+                report.getFurColor(),
+                report.getSex().getValue(),
+                report.getNeutering().toString(),
+                report.getSignificant(),
+                report.getCareName(),
+                report.getAddress(),
+                report.getLatitude().doubleValue(),
+                report.getLongitude().doubleValue(),
+                report.getCareTel(),
+                report.getDate().toString(),
+                report.getFoundLocation(),
+                report.getNoticeDuration(),
+                report.getNoticeNumber(),
+                report.getAuthority(),
+                interest
+        );
+    }
+}

--- a/src/main/java/com/kuit/findyou/domain/report/strategy/ProtectingReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/strategy/ProtectingReportDetailStrategy.java
@@ -2,11 +2,18 @@ package com.kuit.findyou.domain.report.strategy;
 
 import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.model.ProtectingReport;
-import com.kuit.findyou.domain.report.model.Report;
+import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
+import com.kuit.findyou.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.PROTECTING_REPORT_NOT_FOUND;
+
+@RequiredArgsConstructor
 @Component("PROTECTING")
 public class ProtectingReportDetailStrategy implements ReportDetailStrategy<ProtectingReport, ProtectingReportDetailResponseDTO> {
+
+    private final ProtectingReportRepository protectingReportRepository;
 
     @Override
     public ProtectingReportDetailResponseDTO getDetail(ProtectingReport report, boolean interest) {
@@ -32,5 +39,11 @@ public class ProtectingReportDetailStrategy implements ReportDetailStrategy<Prot
                 report.getAuthority(),
                 interest
         );
+    }
+
+    @Override
+    public ProtectingReport getReport(Long reportId) {
+        return protectingReportRepository.findWithImagesById(reportId)
+                .orElseThrow(() -> new CustomException(PROTECTING_REPORT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/report/strategy/ReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/strategy/ReportDetailStrategy.java
@@ -2,6 +2,10 @@ package com.kuit.findyou.domain.report.strategy;
 
 import com.kuit.findyou.domain.report.model.Report;
 
+
 public interface ReportDetailStrategy<REPORT_TYPE extends Report, DTO_TYPE> {
+
     DTO_TYPE getDetail(REPORT_TYPE report, boolean interest);
+
+    REPORT_TYPE getReport(Long reportId);
 }

--- a/src/main/java/com/kuit/findyou/domain/report/strategy/ReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/strategy/ReportDetailStrategy.java
@@ -3,5 +3,5 @@ package com.kuit.findyou.domain.report.strategy;
 import com.kuit.findyou.domain.report.model.Report;
 
 public interface ReportDetailStrategy<REPORT_TYPE extends Report, DTO_TYPE> {
-    DTO_TYPE getDetail(REPORT_TYPE report);
+    DTO_TYPE getDetail(REPORT_TYPE report, boolean interest);
 }

--- a/src/main/java/com/kuit/findyou/domain/report/strategy/ReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/strategy/ReportDetailStrategy.java
@@ -1,0 +1,7 @@
+package com.kuit.findyou.domain.report.strategy;
+
+import com.kuit.findyou.domain.report.model.Report;
+
+public interface ReportDetailStrategy<REPORT_TYPE extends Report, DTO_TYPE> {
+    DTO_TYPE getDetail(REPORT_TYPE report);
+}

--- a/src/main/java/com/kuit/findyou/domain/report/strategy/WitnessReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/strategy/WitnessReportDetailStrategy.java
@@ -2,10 +2,18 @@ package com.kuit.findyou.domain.report.strategy;
 
 import com.kuit.findyou.domain.report.dto.response.WitnessReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.model.WitnessReport;
+import com.kuit.findyou.domain.report.repository.WitnessReportRepository;
+import com.kuit.findyou.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.WITNESS_REPORT_NOT_FOUND;
+
+@RequiredArgsConstructor
 @Component("WITNESS")
 public class WitnessReportDetailStrategy implements ReportDetailStrategy<WitnessReport, WitnessReportDetailResponseDTO> {
+
+    private final WitnessReportRepository witnessReportRepository;
 
     @Override
     public WitnessReportDetailResponseDTO getDetail(WitnessReport report, boolean interest) {
@@ -23,6 +31,12 @@ public class WitnessReportDetailStrategy implements ReportDetailStrategy<Witness
                 report.getDate().toString(),
                 interest
         );
+    }
+
+    @Override
+    public WitnessReport getReport(Long reportId) {
+        return witnessReportRepository.findWithImagesById(reportId)
+                .orElseThrow(() -> new CustomException(WITNESS_REPORT_NOT_FOUND));
     }
 }
 

--- a/src/main/java/com/kuit/findyou/domain/report/strategy/WitnessReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/strategy/WitnessReportDetailStrategy.java
@@ -1,0 +1,28 @@
+package com.kuit.findyou.domain.report.strategy;
+
+import com.kuit.findyou.domain.report.dto.response.WitnessReportDetailResponseDTO;
+import com.kuit.findyou.domain.report.model.WitnessReport;
+import org.springframework.stereotype.Component;
+
+@Component("WITNESS")
+public class WitnessReportDetailStrategy implements ReportDetailStrategy<WitnessReport, WitnessReportDetailResponseDTO> {
+
+    @Override
+    public WitnessReportDetailResponseDTO getDetail(WitnessReport report, boolean interest) {
+        return new WitnessReportDetailResponseDTO(
+                report.getReportImagesUrlList(),
+                report.getBreed(),
+                report.getTag().getValue(),
+                report.getFurColor(),
+                report.getSignificant(),
+                report.getLandmark(),       // witnessLocation
+                report.getAddress(),        // witnessAddress
+                report.getLatitude().doubleValue(),
+                report.getLongitude().doubleValue(),
+                report.getReporterName(),
+                report.getDate().toString(),
+                interest
+        );
+    }
+}
+

--- a/src/main/java/com/kuit/findyou/domain/report/strategy/WitnessReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/strategy/WitnessReportDetailStrategy.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.WITNESS_REPORT_NOT_FOUND;
 
 @RequiredArgsConstructor
-@Component("WITNESS")
+@Component
 public class WitnessReportDetailStrategy implements ReportDetailStrategy<WitnessReport, WitnessReportDetailResponseDTO> {
 
     private final WitnessReportRepository witnessReportRepository;

--- a/src/main/java/com/kuit/findyou/domain/report/strategy/config/ReportDetailStrategyConfig.java
+++ b/src/main/java/com/kuit/findyou/domain/report/strategy/config/ReportDetailStrategyConfig.java
@@ -1,0 +1,32 @@
+package com.kuit.findyou.domain.report.strategy.config;
+
+import com.kuit.findyou.domain.report.model.Report;
+import com.kuit.findyou.domain.report.model.ReportTag;
+import com.kuit.findyou.domain.report.strategy.MissingReportDetailStrategy;
+import com.kuit.findyou.domain.report.strategy.ProtectingReportDetailStrategy;
+import com.kuit.findyou.domain.report.strategy.ReportDetailStrategy;
+import com.kuit.findyou.domain.report.strategy.WitnessReportDetailStrategy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class ReportDetailStrategyConfig {
+
+    private final ProtectingReportDetailStrategy protectingStrategy;
+    private final MissingReportDetailStrategy missingStrategy;
+    private final WitnessReportDetailStrategy witnessStrategy;
+
+    @Bean
+    public Map<ReportTag, ReportDetailStrategy<? extends Report, ?>> reportDetailStrategies() {
+        return Map.of(
+                ReportTag.PROTECTING, protectingStrategy,
+                ReportTag.MISSING, missingStrategy,
+                ReportTag.WITNESS, witnessStrategy
+        );
+    }
+}
+

--- a/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
@@ -2,6 +2,7 @@ package com.kuit.findyou.global.common.exception_handler;
 
 import com.kuit.findyou.global.common.exception.CustomException;
 import com.kuit.findyou.global.common.response.BaseErrorResponse;
+import com.kuit.findyou.global.common.response.BaseResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.TypeMismatchException;
 import org.springframework.http.HttpStatusCode;
@@ -20,48 +21,38 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 public class GlobalControllerAdvice {
     // 잘못된 요청일 경우
     @ExceptionHandler(TypeMismatchException.class)
-    public ResponseEntity<BaseErrorResponse> handle_TypeMismatchException(TypeMismatchException e){
+    public BaseErrorResponse handle_TypeMismatchException(TypeMismatchException e){
         log.error("[handle_TypeMismatchException]", e);
-        return ResponseEntity
-                .badRequest()
-                .body(new BaseErrorResponse(BAD_REQUEST));
+        return new BaseErrorResponse(BAD_REQUEST);
     }
 
     // 요청한 api가 없을 경우
     @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<BaseErrorResponse> handle_NoHandlerFoundException(NoHandlerFoundException e){
+    public BaseErrorResponse handle_NoHandlerFoundException(NoHandlerFoundException e){
         log.error("[handle_NoHandlerFoundException]", e);
-        return ResponseEntity
-                .badRequest()
-                .body(new BaseErrorResponse(API_NOT_FOUND));
+        return new BaseErrorResponse(API_NOT_FOUND);
     }
 
     // 런타임 오류가 발생한 경우
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<BaseErrorResponse> handle_RuntimeException(RuntimeException e) {
+    public BaseErrorResponse handle_RuntimeException(RuntimeException e) {
         log.error("[handle_RuntimeException]", e);
-        return ResponseEntity
-                .internalServerError()
-                .body(new BaseErrorResponse(INTERNAL_SERVER_ERROR));
+        return new BaseErrorResponse(INTERNAL_SERVER_ERROR);
     }
 
     // 요청에 필요한 인자가 없는 경우
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<BaseErrorResponse> handle_MethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    public BaseErrorResponse handle_MethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("[handle_MethodArgumentNotValidException]", e);
         FieldError fieldError = e.getBindingResult().getFieldError(); // NPE 가능성으로 인해 검증
         String defaultMessage = (fieldError != null) ? e.getBindingResult().getFieldError().getDefaultMessage() : "Invalid request";
-        return ResponseEntity
-                .badRequest()
-                .body(new BaseErrorResponse(BAD_REQUEST, defaultMessage));
+        return new BaseErrorResponse(BAD_REQUEST, defaultMessage);
     }
 
     // 커스텀 예외의 경우
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<BaseErrorResponse> handle_CustomException(CustomException e) {
+    public BaseErrorResponse handle_CustomException(CustomException e) {
         log.error("[handle_CustomException]", e);
-        return ResponseEntity
-                .status(HttpStatusCode.valueOf(e.getExceptionStatus().getCode()))
-                .body(new BaseErrorResponse(e.getExceptionStatus()));
+        return new BaseErrorResponse(e.getExceptionStatus());
     }
 }

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -17,7 +17,13 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     FORBIDDEN(403, "권한이 없습니다."),
     API_NOT_FOUND(404, "존재하지 않는 API입니다."),
     METHOD_NOT_ALLOWED(405, "유효하지 않은 Http 메서드입니다."),
-    INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다.");
+    INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다."),
+
+    // 글 - Report
+    PROTECTING_REPORT_NOT_FOUND(404, "보호글이 존재하지 않습니다."),
+    MISSING_REPORT_NOT_FOUND(404, "실종 신고글이 존재하지 않습니다."),
+    WITNESS_REPORT_NOT_FOUND(404, "목격 신고글이 존재하지 않습니다."),
+    ILLEGAL_TAG(500, "잘못된 태그값입니다.");
 
     private final boolean success = false;
     private final int code;

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -19,10 +19,13 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     METHOD_NOT_ALLOWED(405, "유효하지 않은 Http 메서드입니다."),
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다."),
 
+    // 유저 - User
+    USER_NOT_FOUND(404, "존재하지 않는 유저입니다."),
+
     // 글 - Report
-    PROTECTING_REPORT_NOT_FOUND(404, "보호글이 존재하지 않습니다."),
-    MISSING_REPORT_NOT_FOUND(404, "실종 신고글이 존재하지 않습니다."),
-    WITNESS_REPORT_NOT_FOUND(404, "목격 신고글이 존재하지 않습니다."),
+    PROTECTING_REPORT_NOT_FOUND(404, "존재하지 않는 보호글입니다."),
+    MISSING_REPORT_NOT_FOUND(404, "존재하지 않는 실종 신고글입니다."),
+    WITNESS_REPORT_NOT_FOUND(404, "존재하지 않는 목격 신고글입니다."),
     ILLEGAL_TAG(500, "잘못된 태그값입니다.");
 
     private final boolean success = false;

--- a/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
@@ -13,6 +13,24 @@ public enum SwaggerResponseDescription {
 
     TEST(new LinkedHashSet<>(Set.of(
             TEST_EXCEPTION
+    ))),
+
+    PROTECTING_REPORT_DETAIL(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            PROTECTING_REPORT_NOT_FOUND,
+            ILLEGAL_TAG
+    ))),
+
+    MISSING_REPORT_DETAIL(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            MISSING_REPORT_NOT_FOUND,
+            ILLEGAL_TAG
+    ))),
+
+    WITNESS_REPORT_DETAIL(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            WITNESS_REPORT_NOT_FOUND,
+            ILLEGAL_TAG
     )));
 
     private final Set<BaseExceptionResponseStatus> exceptionResponseStatusSet;

--- a/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
@@ -17,20 +17,17 @@ public enum SwaggerResponseDescription {
 
     PROTECTING_REPORT_DETAIL(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
-            PROTECTING_REPORT_NOT_FOUND,
-            ILLEGAL_TAG
+            PROTECTING_REPORT_NOT_FOUND
     ))),
 
     MISSING_REPORT_DETAIL(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
-            MISSING_REPORT_NOT_FOUND,
-            ILLEGAL_TAG
+            MISSING_REPORT_NOT_FOUND
     ))),
 
     WITNESS_REPORT_DETAIL(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
-            WITNESS_REPORT_NOT_FOUND,
-            ILLEGAL_TAG
+            WITNESS_REPORT_NOT_FOUND
     )));
 
     private final Set<BaseExceptionResponseStatus> exceptionResponseStatusSet;


### PR DESCRIPTION
## Related issue 🛠
- closed #9 

## Work Description 📝
- 보호글/실종신고글/목격신고글 각각에 대한 상세 조회 로직을 구현하였습니다.

### 전략 패턴을 활용한 동물 정보 상세 조회 API 구현

Missing, Protecting, WitnessReport 모두 Report 라는 부모 클래스를 갖는다는 점에서, 다형성을 최대한 사용해보면 좋겠다는 생각을 하게되었습니다.
따라서 여러 디자인 패턴들 중 가장 대중적인 패턴중 하나인 전략 패턴과, 자바의 제네릭을 활용 하여 V1의 로직을 리팩토링 해보고자 하였습니다. 

### 전략 인터페이스 정의
따라서 **`ReportDetailStrategy<T extends Report, R>`** 라는 인터페이스를 정의하고, 각 Report 타입별로 구현체를 분리해 책임을 위임했습니다.

<img width="550" height="61" alt="스크린샷 2025-07-10 오후 9 03 18" src="https://github.com/user-attachments/assets/0ae87b77-064e-4d4e-8989-0f8004b34449" />

### 전략 인터페이스 구현체
전략 인터페이스의 실제 구현은 **`ProtectingReportDetailStrategy, MissingReportDetailStrategy, WitnessReportDetailStrategy`** 에서 담당합니다.

<img width="550" height="532" alt="스크린샷 2025-07-10 오후 9 03 54" src="https://github.com/user-attachments/assets/425807ae-bf40-41ec-8395-25ccc584c09e" />

### ReportDetailService 
그렇게 구현한 구현체들을 ReportDetailService 에서 활용합니다.
클라이언트가 진입한 API 에 해당하는 Tag 값을 기반으로 전략을 선택하고 동작하게됩니다.
<img width="550" height="558" alt="스크린샷 2025-07-10 오후 9 04 30" src="https://github.com/user-attachments/assets/3c054bb7-de70-4424-993d-698282737ec1" />

이를 통해 서비스 레이어는 타입에 의존하지 않고, 새로운 상세 타입이 추가되어도 확장에 유리하도록 설계하였습니다.

### 1+1 쿼리 제거
추가적으로, findById 를 통해 Report 정보를 얻어오고, 그 후에 getReportImages 를 통해 연관된 이미지들을 조회해오는 경우, Report 를 조회하는 쿼리 1회 + reportImages를 조회할 때 Lazy Loading 에 의해 전송되는 쿼리 1회 총 2회. 즉 1+1 쿼리 상황이 생기기 때문에, 위와 같은 상황을 방지하고자 @EntityGraph 를 활용하여 1번의 쿼리로 reportImage 까지 모두 가져올 수 있도록 하였습니다.
<img width="439" height="47" alt="스크린샷 2025-07-10 오후 9 08 35" src="https://github.com/user-attachments/assets/86d417cb-8642-441f-83c8-0ddcbdaf7fd4" />


## Screenshot 📸

<img width="434" height="449" alt="스크린샷 2025-07-10 오후 9 09 05" src="https://github.com/user-attachments/assets/4a638f83-16eb-41f2-9653-87b2f489ece0" />

<img width="506" height="587" alt="스크린샷 2025-07-10 오후 9 09 16" src="https://github.com/user-attachments/assets/18544e49-0341-4cb1-9a9c-2a72cfc0a533" />

<img width="492" height="528" alt="스크린샷 2025-07-10 오후 9 09 32" src="https://github.com/user-attachments/assets/ac8ddb9e-8062-4264-b9f5-c3fa88721001" />

## Uncompleted Tasks 😅
- [ ] 테스트 코드 구현

## To Reviewers 📢
원래 테스트 코드까지 구현한 후에 PR을 올릴까 하였었는데, 그럼 PR의 크기가 너무 커질 것 같아서 우선 올려둔 후에 이후 PR에서 테스트 코드 작성하겠습니다!