### PR TITLE
[Feat] 로그인 및 JWT 기반 인가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,11 @@ dependencies {
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	// Security
+	implementation("org.springframework.boot:spring-boot-starter-security")
+	testImplementation("org.springframework.security:spring-security-test")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -1,11 +1,25 @@
 package com.kuit.findyou.domain.auth.controller;
 
+import com.kuit.findyou.domain.auth.dto.KakaoLoginRequest;
+import com.kuit.findyou.domain.auth.dto.KakaoLoginResponse;
+import com.kuit.findyou.domain.auth.service.AuthService;
+import com.kuit.findyou.global.common.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@RequestMapping("auth")
+@RequiredArgsConstructor
+@RequestMapping("api/v2/auth")
 @RestController
 public class AuthController {
+    private final AuthService authService;
+    @PostMapping("login/kakao")
+    public BaseResponse<KakaoLoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request){
+        log.info("[kakaoLogin]");
+        return BaseResponse.ok(authService.kakaoLogin(request));
+    }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
             summary = "카카오 로그인 API",
             description = "카카오 사용자 식별자를 이용해서 유저 정보와 엑세스 토큰을 얻을 수 있습니다. 가입된 회원인지 여부를 반환합니다."
     )
-    @PostMapping("login/kakao")
+    @PostMapping("/login/kakao")
     @CustomExceptionDescription(KAKAO_LOGIN)
     public BaseResponse<KakaoLoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request){
         log.info("[kakaoLogin]");

--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -5,7 +5,6 @@ import com.kuit.findyou.domain.auth.dto.KakaoLoginResponse;
 import com.kuit.findyou.domain.auth.service.AuthService;
 import com.kuit.findyou.global.common.annotation.CustomExceptionDescription;
 import com.kuit.findyou.global.common.response.BaseResponse;
-import com.kuit.findyou.global.common.swagger.SwaggerResponseDescription;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -3,7 +3,11 @@ package com.kuit.findyou.domain.auth.controller;
 import com.kuit.findyou.domain.auth.dto.KakaoLoginRequest;
 import com.kuit.findyou.domain.auth.dto.KakaoLoginResponse;
 import com.kuit.findyou.domain.auth.service.AuthService;
+import com.kuit.findyou.global.common.annotation.CustomExceptionDescription;
 import com.kuit.findyou.global.common.response.BaseResponse;
+import com.kuit.findyou.global.common.swagger.SwaggerResponseDescription;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,13 +15,22 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.KAKAO_LOGIN;
+
+@Tag(name = "Login", description = "로그인 관련 API")
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("api/v2/auth")
 @RestController
 public class AuthController {
     private final AuthService authService;
+
+    @Operation(
+            summary = "카카오 로그인 API",
+            description = "카카오 사용자 식별자를 이용해서 유저 정보와 엑세스 토큰을 얻을 수 있습니다. 가입된 회원인지 여부를 반환합니다."
+    )
     @PostMapping("login/kakao")
+    @CustomExceptionDescription(KAKAO_LOGIN)
     public BaseResponse<KakaoLoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request){
         log.info("[kakaoLogin]");
         return BaseResponse.ok(authService.kakaoLogin(request));

--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -1,0 +1,11 @@
+package com.kuit.findyou.domain.auth.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequestMapping("auth")
+@RestController
+public class AuthController {
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/KakaoLoginRequest.java
@@ -1,6 +1,10 @@
 package com.kuit.findyou.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인 요청 DTO")
 public record KakaoLoginRequest(
+        @Schema(description = "사용자 카카오 ID", example = "12345678")
         Long kakaoId
 ) {
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/KakaoLoginRequest.java
@@ -1,0 +1,6 @@
+package com.kuit.findyou.domain.auth.dto;
+
+public record KakaoLoginRequest(
+        Long kakaoId
+) {
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/KakaoLoginResponse.java
@@ -1,7 +1,17 @@
 package com.kuit.findyou.domain.auth.dto;
 
+import com.kuit.findyou.domain.user.model.User;
+
 public record KakaoLoginResponse(
         UserInfoDto userInfo,
         Boolean isFirstLogin
 ) {
+    public static KakaoLoginResponse fromUserAndAccessToken(User user, String accessToken) {
+        UserInfoDto userInfo = new UserInfoDto(user.getId(), user.getName(), accessToken);
+        return new KakaoLoginResponse(userInfo, true);
+    }
+
+    public static KakaoLoginResponse notFound() {
+        return new KakaoLoginResponse(null, true);
+    }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/KakaoLoginResponse.java
@@ -1,9 +1,13 @@
 package com.kuit.findyou.domain.auth.dto;
 
 import com.kuit.findyou.domain.user.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "카카오 로그인 응답 DTO")
 public record KakaoLoginResponse(
+        @Schema(description = "사용자 정보")
         UserInfoDto userInfo,
+        @Schema(description = "첫 로그인 여부 = 회원가입 여부", example = "false")
         Boolean isFirstLogin
 ) {
     public static KakaoLoginResponse fromUserAndAccessToken(User user, String accessToken) {

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/KakaoLoginResponse.java
@@ -1,0 +1,7 @@
+package com.kuit.findyou.domain.auth.dto;
+
+public record KakaoLoginResponse(
+        UserInfoDto userInfo,
+        Boolean isFirstLogin
+) {
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/KakaoLoginResponse.java
@@ -12,7 +12,7 @@ public record KakaoLoginResponse(
 ) {
     public static KakaoLoginResponse fromUserAndAccessToken(User user, String accessToken) {
         UserInfoDto userInfo = new UserInfoDto(user.getId(), user.getName(), accessToken);
-        return new KakaoLoginResponse(userInfo, true);
+        return new KakaoLoginResponse(userInfo, false);
     }
 
     public static KakaoLoginResponse notFound() {

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/UserInfoDto.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/UserInfoDto.java
@@ -1,8 +1,13 @@
 package com.kuit.findyou.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record UserInfoDto(
+        @Schema(description = "사용자 식별자", example = "1")
         Long userId,
+        @Schema(description = "사용자 닉네임", example = "유저1")
         String nickname,
+        @Schema(description = "찾아유 엑세스 토큰", example = "token1234token1234token1234")
         String accessToken
 ) {
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/UserInfoDto.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/UserInfoDto.java
@@ -1,0 +1,8 @@
+package com.kuit.findyou.domain.auth.dto;
+
+public record UserInfoDto(
+        Long userId,
+        String nickname,
+        String accessToken
+) {
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
@@ -20,17 +20,11 @@ public class AuthService {
     public KakaoLoginResponse kakaoLogin(KakaoLoginRequest request) {
         log.info("[kakaoLogin] kakaoId = {}", request.kakaoId());
 
-        // 유저를 찾는다
-        Optional<User> optUser = userRepository.findByKakaoId(request.kakaoId());
-
-        // 없으면 회원가입 유도
-        if(optUser.isEmpty()){
-            return KakaoLoginResponse.notFound();
-        }
-
-        // 있으면 회원정보와 엑세스 토큰 발급
-        User loginUser = optUser.get();
-        String token = jwtUtil.createAccessJwt(loginUser.getId(), loginUser.getRole());
-        return KakaoLoginResponse.fromUserAndAccessToken(loginUser, token);
+        return userRepository.findByKakaoId(request.kakaoId())
+                .map(loginUser -> {
+                    String token = jwtUtil.createAccessJwt(loginUser.getId(), loginUser.getRole());
+                    return KakaoLoginResponse.fromUserAndAccessToken(loginUser, token);
+                })
+                .orElseGet(() -> KakaoLoginResponse.notFound());
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
@@ -22,9 +22,13 @@ public class AuthService {
 
         return userRepository.findByKakaoId(request.kakaoId())
                 .map(loginUser -> {
+                    log.info("[kakaoLogin] user found");
                     String token = jwtUtil.createAccessJwt(loginUser.getId(), loginUser.getRole());
                     return KakaoLoginResponse.fromUserAndAccessToken(loginUser, token);
                 })
-                .orElseGet(() -> KakaoLoginResponse.notFound());
+                .orElseGet(() -> {
+                    log.info("[kakaoLogin] user not found");
+                    return KakaoLoginResponse.notFound();
+                });
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
@@ -30,7 +30,7 @@ public class AuthService {
 
         // 있으면 회원정보와 엑세스 토큰 발급
         User loginUser = optUser.get();
-        String token = jwtUtil.createAccessJwt(loginUser.getId());
+        String token = jwtUtil.createAccessJwt(loginUser.getId(), loginUser.getRole());
         return KakaoLoginResponse.fromUserAndAccessToken(loginUser, token);
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
@@ -1,0 +1,9 @@
+package com.kuit.findyou.domain.auth.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class AuthService {
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
@@ -1,9 +1,36 @@
 package com.kuit.findyou.domain.auth.service;
 
+import com.kuit.findyou.domain.auth.dto.KakaoLoginRequest;
+import com.kuit.findyou.domain.auth.dto.KakaoLoginResponse;
+import com.kuit.findyou.domain.user.model.User;
+import com.kuit.findyou.domain.user.repository.UserRepository;
+import com.kuit.findyou.global.jwt.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Slf4j
+@RequiredArgsConstructor
 @Service
 public class AuthService {
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    public KakaoLoginResponse kakaoLogin(KakaoLoginRequest request) {
+        log.info("[kakaoLogin] kakaoId = {}", request.kakaoId());
+
+        // 유저를 찾는다
+        Optional<User> optUser = userRepository.findByKakaoId(request.kakaoId());
+
+        // 없으면 회원가입 유도
+        if(optUser.isEmpty()){
+            return KakaoLoginResponse.notFound();
+        }
+
+        // 있으면 회원정보와 엑세스 토큰 발급
+        User loginUser = optUser.get();
+        String token = jwtUtil.createAccessJwt(loginUser.getId());
+        return KakaoLoginResponse.fromUserAndAccessToken(loginUser, token);
+    }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
@@ -2,33 +2,7 @@ package com.kuit.findyou.domain.auth.service;
 
 import com.kuit.findyou.domain.auth.dto.KakaoLoginRequest;
 import com.kuit.findyou.domain.auth.dto.KakaoLoginResponse;
-import com.kuit.findyou.domain.user.model.User;
-import com.kuit.findyou.domain.user.repository.UserRepository;
-import com.kuit.findyou.global.jwt.util.JwtUtil;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
-@Slf4j
-@RequiredArgsConstructor
-@Service
-public class AuthService {
-    private final UserRepository userRepository;
-    private final JwtUtil jwtUtil;
-    public KakaoLoginResponse kakaoLogin(KakaoLoginRequest request) {
-        log.info("[kakaoLogin] kakaoId = {}", request.kakaoId());
-
-        return userRepository.findByKakaoId(request.kakaoId())
-                .map(loginUser -> {
-                    log.info("[kakaoLogin] user found");
-                    String token = jwtUtil.createAccessJwt(loginUser.getId(), loginUser.getRole());
-                    return KakaoLoginResponse.fromUserAndAccessToken(loginUser, token);
-                })
-                .orElseGet(() -> {
-                    log.info("[kakaoLogin] user not found");
-                    return KakaoLoginResponse.notFound();
-                });
-    }
+public interface AuthService {
+    KakaoLoginResponse kakaoLogin(KakaoLoginRequest request);
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,31 @@
+package com.kuit.findyou.domain.auth.service;
+
+import com.kuit.findyou.domain.auth.dto.KakaoLoginRequest;
+import com.kuit.findyou.domain.auth.dto.KakaoLoginResponse;
+import com.kuit.findyou.domain.user.repository.UserRepository;
+import com.kuit.findyou.global.jwt.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AuthServiceImpl implements AuthService {
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    public KakaoLoginResponse kakaoLogin(KakaoLoginRequest request) {
+        log.info("[kakaoLogin] kakaoId = {}", request.kakaoId());
+
+        return userRepository.findByKakaoId(request.kakaoId())
+                .map(loginUser -> {
+                    log.info("[kakaoLogin] user found");
+                    String token = jwtUtil.createAccessJwt(loginUser.getId(), loginUser.getRole());
+                    return KakaoLoginResponse.fromUserAndAccessToken(loginUser, token);
+                })
+                .orElseGet(() -> {
+                    log.info("[kakaoLogin] user not found");
+                    return KakaoLoginResponse.notFound();
+                });
+    }
+}

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -9,6 +9,7 @@ import com.kuit.findyou.domain.report.model.*;
 import com.kuit.findyou.domain.report.service.facade.ReportServiceFacade;
 import com.kuit.findyou.global.common.annotation.CustomExceptionDescription;
 import com.kuit.findyou.global.common.response.BaseResponse;
+import com.kuit.findyou.global.jwt.annotation.LoginUserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -33,9 +34,10 @@ public class ReportController {
     @GetMapping("/protecting-reports/{reportId}")
     @CustomExceptionDescription(PROTECTING_REPORT_DETAIL)
     public BaseResponse<ProtectingReportDetailResponseDTO> getProtectingReportDetail(
-            @PathVariable("reportId") Long reportId) {
-
-        ProtectingReportDetailResponseDTO detail = reportServiceFacade.getReportDetail(ReportTag.PROTECTING, reportId, 1L);
+            @PathVariable("reportId") Long reportId,
+            @LoginUserId Long userId
+    ) {
+        ProtectingReportDetailResponseDTO detail = reportServiceFacade.getReportDetail(ReportTag.PROTECTING, reportId, userId);
         return BaseResponse.ok(detail);
     }
 
@@ -43,9 +45,10 @@ public class ReportController {
     @GetMapping("/missing-reports/{reportId}")
     @CustomExceptionDescription(MISSING_REPORT_DETAIL)
     public BaseResponse<MissingReportDetailResponseDTO> getMissingReportDetail(
-            @PathVariable("reportId") Long reportId) {
-
-        MissingReportDetailResponseDTO detail = reportServiceFacade.getReportDetail(ReportTag.MISSING, reportId, 1L);
+            @PathVariable("reportId") Long reportId,
+            @LoginUserId Long userId
+    ) {
+        MissingReportDetailResponseDTO detail = reportServiceFacade.getReportDetail(ReportTag.MISSING, reportId, userId);
         return BaseResponse.ok(detail);
     }
 
@@ -53,9 +56,10 @@ public class ReportController {
     @GetMapping("/witness-reports/{reportId}")
     @CustomExceptionDescription(WITNESS_REPORT_DETAIL)
     public BaseResponse<WitnessReportDetailResponseDTO> getWitnessReportDetail(
-            @PathVariable("reportId") Long reportId) {
-
-        WitnessReportDetailResponseDTO detail = reportServiceFacade.getReportDetail(ReportTag.WITNESS, reportId, 1L);
+            @PathVariable("reportId") Long reportId,
+            @LoginUserId Long userId
+    ) {
+        WitnessReportDetailResponseDTO detail = reportServiceFacade.getReportDetail(ReportTag.WITNESS, reportId, userId);
         return BaseResponse.ok(detail);
     }
 
@@ -69,9 +73,10 @@ public class ReportController {
             @RequestParam(required = false) String species,
             @RequestParam(required = false) String breeds,
             @RequestParam(required = false) String address,
-            @RequestParam Long lastReportId
+            @RequestParam Long lastReportId,
+            @LoginUserId Long userId
     ) {
-        CardResponseDTO result = reportServiceFacade.retrieveReportsWithFilters(type, startDate, endDate, species, breeds, address, lastReportId, 1L);
+        CardResponseDTO result = reportServiceFacade.retrieveReportsWithFilters(type, startDate, endDate, species, breeds, address, lastReportId, userId);
         return BaseResponse.ok(result);
     }
 

--- a/src/main/java/com/kuit/findyou/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/user/repository/UserRepository.java
@@ -4,6 +4,9 @@ import com.kuit.findyou.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByKakaoId(Long kakaoId);
 }

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -19,6 +19,11 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     METHOD_NOT_ALLOWED(405, "유효하지 않은 Http 메서드입니다."),
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다."),
 
+    // JWT 토큰
+    INVALID_JWT(401, "올바르지 않은 토큰입니다."),
+    EXPIRED_JWT(401, "만료된 토큰입니다"),
+    JWT_NOT_FOUND(400, "토큰을 찾을 수 없습니다"),
+
     // 유저 - User
     USER_NOT_FOUND(404, "존재하지 않는 유저입니다."),
 

--- a/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
@@ -11,6 +11,8 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 @Getter
 public enum SwaggerResponseDescription {
 
+    KAKAO_LOGIN(new LinkedHashSet<>(Set.of())),
+
     TEST(new LinkedHashSet<>(Set.of(
             TEST_EXCEPTION
     ))),
@@ -33,6 +35,8 @@ public enum SwaggerResponseDescription {
     RETRIEVE_REPORTS(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND
     )));
+
+
 
     private final Set<BaseExceptionResponseStatus> exceptionResponseStatusSet;
 

--- a/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
+++ b/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.kuit.findyou.global.config;
 
-import com.kuit.findyou.global.jwt.entrypoint.CustomAuthenticationEntryPoint;
+import com.kuit.findyou.global.jwt.security.CustomAuthenticationEntryPoint;
 import com.kuit.findyou.global.jwt.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -49,6 +49,10 @@ public class SecurityConfig {
         // 토큰 검증 필터 추가
         http
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        // 토큰 검증 예외 처리 추가
+        http
+                .exceptionHandling(configurer -> configurer.authenticationEntryPoint(customAuthenticationEntryPoint));
 
         http
                 .sessionManagement((session)->session

--- a/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
+++ b/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
@@ -1,0 +1,59 @@
+package com.kuit.findyou.global.config;
+
+import com.kuit.findyou.global.jwt.entrypoint.CustomAuthenticationEntryPoint;
+import com.kuit.findyou.global.jwt.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final String[] PERMIT_URL = {
+            "/api/v2/auth/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/swagger-ui/index.html"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+
+        http
+                .csrf((auth) -> auth.disable());
+
+        http
+                .formLogin((auth)->auth.disable());
+
+        http
+                .httpBasic((auth)->auth.disable());
+
+        // 토큰 기반 인증 비활성화
+//        http
+//                .authorizeHttpRequests((auth)-> auth
+//                        .anyRequest().permitAll());
+
+        // 토큰 기반 인증 활성화
+        http
+                .authorizeHttpRequests((auth)-> auth
+                        .requestMatchers(PERMIT_URL).permitAll()
+                        .anyRequest().authenticated());
+
+        // 토큰 검증 필터 추가
+        http
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        http
+                .sessionManagement((session)->session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/config/WebConfig.java
+++ b/src/main/java/com/kuit/findyou/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.kuit.findyou.global.config;
+
+import com.kuit.findyou.global.jwt.argument_resolver.LoginUserIdArgumentResolver;
+import com.kuit.findyou.global.jwt.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final JwtUtil jwtUtil;
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginUserIdArgumentResolver(jwtUtil));
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/annotation/LoginUserId.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/annotation/LoginUserId.java
@@ -1,0 +1,11 @@
+package com.kuit.findyou.global.jwt.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUserId {
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/argument_resolver/LoginUserIdArgumentResolver.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/argument_resolver/LoginUserIdArgumentResolver.java
@@ -11,6 +11,8 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import static com.kuit.findyou.global.jwt.constant.JwtAutenticationFilterConstants.TOKEN_FOR_ARGUMENT_RESOLVER;
+
 @Slf4j
 @RequiredArgsConstructor
 public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolver {
@@ -23,7 +25,7 @@ public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolve
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        String token = (String) request.getAttribute("token");
+        String token = (String) request.getAttribute(TOKEN_FOR_ARGUMENT_RESOLVER.getValue());
         Long userId = jwtUtil.getUserId(token);
         log.info("userId = {}",  userId);
         return userId;

--- a/src/main/java/com/kuit/findyou/global/jwt/argument_resolver/LoginUserIdArgumentResolver.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/argument_resolver/LoginUserIdArgumentResolver.java
@@ -1,0 +1,31 @@
+package com.kuit.findyou.global.jwt.argument_resolver;
+
+import com.kuit.findyou.global.jwt.annotation.LoginUserId;
+import com.kuit.findyou.global.jwt.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j
+@RequiredArgsConstructor
+public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+    private final JwtUtil jwtUtil;
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(Long.class) && parameter.hasParameterAnnotation(LoginUserId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = (String) request.getAttribute("token");
+        Long userId = jwtUtil.getUserId(token);
+        log.info("userId = {}",  userId);
+        return userId;
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/constant/JwtAutenticationFilterConstants.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/constant/JwtAutenticationFilterConstants.java
@@ -1,0 +1,18 @@
+package com.kuit.findyou.global.jwt.constant;
+
+public enum JwtAutenticationFilterConstants {
+    AUTH0RIZATION("Authorization"),
+    TOKEN_PREFIX("Bearer "),
+    TOKEN_FOR_ARGUMENT_RESOLVER("token"),
+    JWT_ERROR_CODE("jwt_error_code");
+
+    private final String value;
+
+    private JwtAutenticationFilterConstants(String value){
+        this.value = value;
+    }
+
+    public String getValue(){
+        return this.value;
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/constant/JwtErrorCode.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/constant/JwtErrorCode.java
@@ -1,0 +1,5 @@
+package com.kuit.findyou.global.jwt.constant;
+
+public enum JwtErrorCode {
+    INVALID_JWT_ERROR, EXPIRED_JWT_ERROR, JWT_NOT_FOUND_ERROR;
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/exception/InvalidJwtException.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/exception/InvalidJwtException.java
@@ -1,0 +1,10 @@
+package com.kuit.findyou.global.jwt.exception;
+
+import com.kuit.findyou.global.common.exception.CustomException;
+import com.kuit.findyou.global.common.response.status.ResponseStatus;
+
+public class InvalidJwtException extends CustomException {
+    public InvalidJwtException(ResponseStatus exceptionStatus){
+        super(exceptionStatus);
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/exception/JwtExpiredException.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/exception/JwtExpiredException.java
@@ -1,0 +1,10 @@
+package com.kuit.findyou.global.jwt.exception;
+
+import com.kuit.findyou.global.common.exception.CustomException;
+import com.kuit.findyou.global.common.response.status.ResponseStatus;
+
+public class JwtExpiredException extends CustomException {
+    public JwtExpiredException(ResponseStatus exceptionStatus){
+        super(exceptionStatus);
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/exception/JwtNotFoundException.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/exception/JwtNotFoundException.java
@@ -1,0 +1,10 @@
+package com.kuit.findyou.global.jwt.exception;
+
+import com.kuit.findyou.global.common.exception.CustomException;
+import com.kuit.findyou.global.common.response.status.ResponseStatus;
+
+public class JwtNotFoundException extends CustomException {
+    public JwtNotFoundException(ResponseStatus exceptionStatus){
+        super(exceptionStatus);
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package com.kuit.findyou.global.jwt.filter;
+
+import com.kuit.findyou.domain.user.model.Role;
+import com.kuit.findyou.domain.user.model.User;
+import com.kuit.findyou.global.jwt.security.CustomUserDetails;
+import com.kuit.findyou.global.jwt.util.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+        if(token != null || jwtUtil.validateJwt(token)){
+            // UserDetails 생성
+            Long userId = jwtUtil.getUserId(token);
+            Role role = jwtUtil.getRole(token);
+
+            // CustomUserDetailsService를 거치지 않고 바로 인증 객체 생성
+            User user = User.builder()
+                    .id(userId)
+                    .role(role)
+                    .build();
+            CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+            //스프링 시큐리티 인증 객체를 생성하고 컨텍스트에 저장
+            Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
+
+        // 다음 필터로 진행
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request){
+        String authorization = request.getHeader("Authorization");
+        if(authorization != null && authorization.startsWith("Bearer ")){
+            String token = authorization.split(" ")[1];
+            return token;
+        }
+        log.info("token does not exist!");
+        return null;
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/filter/JwtAuthenticationFilter.java
@@ -29,7 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = resolveToken(request);
-        if(token != null || jwtUtil.validateJwt(token)){
+        if(token != null && jwtUtil.validateJwt(token)){
             // UserDetails 생성
             Long userId = jwtUtil.getUserId(token);
 

--- a/src/main/java/com/kuit/findyou/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/filter/JwtAuthenticationFilter.java
@@ -41,6 +41,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             //스프링 시큐리티 인증 객체를 생성하고 컨텍스트에 저장
             Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
             SecurityContextHolder.getContext().setAuthentication(authToken);
+
+            // token을 argument resolver에 전달
+            request.setAttribute("token", token);
         }
 
         // 다음 필터로 진행

--- a/src/main/java/com/kuit/findyou/global/jwt/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,40 @@
+package com.kuit.findyou.global.jwt.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kuit.findyou.global.common.response.BaseErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.UNAUTHORIZED;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final HandlerExceptionResolver resolver;
+    private final ObjectMapper objectMapper;
+
+    public CustomAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver, ObjectMapper objectMapper){
+        this.resolver = resolver;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException ex) throws IOException {
+        log.info("[commence] 인증 실패로 인증 실패 응답 발생 ");
+
+        BaseErrorResponse body = new BaseErrorResponse(UNAUTHORIZED);
+        response.setStatus(401);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/security/CustomUserDetails.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/security/CustomUserDetails.java
@@ -1,0 +1,53 @@
+package com.kuit.findyou.global.jwt.security;
+
+import com.kuit.findyou.domain.user.model.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().getValue()));
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(user.getId());
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/security/CustomUserDetailsService.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/security/CustomUserDetailsService.java
@@ -31,7 +31,7 @@ public class CustomUserDetailsService implements UserDetailsService {
                 })
                 .orElseThrow(() -> {
                     log.info("[loadUserByUsername] User was not found!! userId={}", userId);
-                    throw new UsernameNotFoundException("User not found with" + userId);
+                    throw new UsernameNotFoundException("User not found with " + userId);
                 });
     }
 }

--- a/src/main/java/com/kuit/findyou/global/jwt/security/CustomUserDetailsService.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/security/CustomUserDetailsService.java
@@ -1,0 +1,37 @@
+package com.kuit.findyou.global.jwt.security;
+
+import com.kuit.findyou.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Long userId;
+        try{
+             userId = Long.parseLong(username);
+        }
+        catch(NumberFormatException e) {
+            log.warn("[loadUserByUsername] Invalid userId format: {}", username);
+            throw new UsernameNotFoundException("Invalid userId format: " + username);
+        }
+
+        return userRepository.findById(userId)
+                .map(user ->{
+                    log.info("[loadUserByUsername] User was found. user = {}",  user);
+                    return new CustomUserDetails(user);
+                })
+                .orElseThrow(() -> {
+                    log.info("[loadUserByUsername] User was not found!! userId={}", userId);
+                    throw new UsernameNotFoundException("User not found with" + userId);
+                });
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtClaimKey.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtClaimKey.java
@@ -1,12 +1,12 @@
 package com.kuit.findyou.global.jwt.util;
 
-public enum JwtClaimKeys {
+public enum JwtClaimKey {
     USER_ID("userId"),
     ROLE("role"),
     TOKEN_TYPE("tokenType");
     private String key;
 
-    private JwtClaimKeys(String key){
+    private JwtClaimKey(String key){
         this.key = key;
     }
 

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtClaimKeys.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtClaimKeys.java
@@ -1,0 +1,16 @@
+package com.kuit.findyou.global.jwt.util;
+
+public enum JwtClaimKeys {
+    USER_ID("userId"),
+    ROLE("role"),
+    TOKEN_TYPE("tokenType");
+    private String key;
+
+    private JwtClaimKeys(String key){
+        this.key = key;
+    }
+
+    public String getKey(){
+        return this.key;
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtClaimValues.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtClaimValues.java
@@ -1,0 +1,16 @@
+package com.kuit.findyou.global.jwt.util;
+
+public enum JwtClaimValues {
+    ACCESS_TOKEN("accessToken"),
+    REFRESH_TOKEN("refreshToken");
+
+    private String value;
+
+    private JwtClaimValues(String value){
+        this.value = value;
+    }
+
+    public String getValue(){
+        return this.value;
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtTokenType.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtTokenType.java
@@ -1,12 +1,12 @@
 package com.kuit.findyou.global.jwt.util;
 
-public enum JwtClaimValues {
+public enum JwtTokenType {
     ACCESS_TOKEN("accessToken"),
     REFRESH_TOKEN("refreshToken");
 
     private String value;
 
-    private JwtClaimValues(String value){
+    private JwtTokenType(String value){
         this.value = value;
     }
 

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.kuit.findyou.global.jwt.util;
 
+import com.kuit.findyou.domain.user.model.Role;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
@@ -31,13 +32,19 @@ public class JwtUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userId", Long.class);
     }
 
+    public Role getRole(String token) {
+        String role = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+        return Role.valueOf(role);
+    }
+
     public String getTokenType(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("tokenType", String.class);
     }
 
-    public String createAccessJwt(Long userId) {
+    public String createAccessJwt(Long userId, Role role) {
         return Jwts.builder()
                 .claim("userId", userId)
+                .claim("role", role.getValue())
                 .claim("tokenType", ACCESS_TOKEN)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + accessTokenExpireMs))

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
@@ -32,16 +32,16 @@ public class JwtUtil {
     }
 
     public Long getUserId(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userId", Long.class);
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(JwtClaimKeys.USER_ID.getKey(), Long.class);
     }
 
     public Role getRole(String token) {
-        String role = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+        String role = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(JwtClaimKeys.ROLE.getKey(), String.class);
         return Role.valueOf(role);
     }
 
     public String getTokenType(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("tokenType", String.class);
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(JwtClaimKeys.TOKEN_TYPE.getKey(), String.class);
     }
 
     public String createAccessJwt(Long userId, Role role) {

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
@@ -1,0 +1,64 @@
+package com.kuit.findyou.global.jwt.util;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil {
+    private final SecretKey secretKey;
+
+    @Value("${findyou.jwt.access.expire-ms}")
+    private long accessTokenExpireMs;
+
+    private static final String ACCESS_TOKEN = "accessToken";
+
+    public JwtUtil(@Value("${findyou.jwt.secret-key}") String secret) {
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public Long getUserId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userId", Long.class);
+    }
+
+    public String getTokenType(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("tokenType", String.class);
+    }
+
+    public String createAccessJwt(Long userId) {
+        return Jwts.builder()
+                .claim("userId", userId)
+                .claim("tokenType", ACCESS_TOKEN)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + accessTokenExpireMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public boolean validateJwt(String token){
+        log.info("validateJwt");
+        try{
+            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
+            return true;
+        } catch (MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
@@ -1,6 +1,9 @@
 package com.kuit.findyou.global.jwt.util;
 
 import com.kuit.findyou.domain.user.model.Role;
+import com.kuit.findyou.global.jwt.exception.InvalidJwtException;
+import com.kuit.findyou.global.jwt.exception.JwtExpiredException;
+import com.kuit.findyou.global.jwt.exception.JwtNotFoundException;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
@@ -13,6 +16,8 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
 
 @Slf4j
 @Component
@@ -50,20 +55,18 @@ public class JwtUtil {
                 .compact();
     }
 
-    public boolean validateJwt(String token){
+    public void validateJwt(String token){
         log.info("validateJwt");
         try{
             Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
-            return true;
         } catch (MalformedJwtException e) {
-            log.info("Invalid JWT Token", e);
+            throw new InvalidJwtException(INVALID_JWT);
         } catch (ExpiredJwtException e) {
-            log.info("Expired JWT Token", e);
+            throw new JwtExpiredException(EXPIRED_JWT);
         } catch (UnsupportedJwtException e) {
-            log.info("Unsupported JWT Token", e);
+            throw new InvalidJwtException(INVALID_JWT);
         } catch (IllegalArgumentException e) {
-            log.info("JWT claims string is empty.", e);
+            throw new JwtNotFoundException(JWT_NOT_FOUND);
         }
-        return false;
     }
 }

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
@@ -22,8 +22,6 @@ public class JwtUtil {
     @Value("${findyou.jwt.access.expire-ms}")
     private long accessTokenExpireMs;
 
-    private static final String ACCESS_TOKEN = "accessToken";
-
     public JwtUtil(@Value("${findyou.jwt.secret-key}") String secret) {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
@@ -43,9 +41,9 @@ public class JwtUtil {
 
     public String createAccessJwt(Long userId, Role role) {
         return Jwts.builder()
-                .claim("userId", userId)
-                .claim("role", role.name())
-                .claim("tokenType", ACCESS_TOKEN)
+                .claim(JwtClaimKeys.USER_ID.getKey(), userId)
+                .claim(JwtClaimKeys.ROLE.getKey(), role.name())
+                .claim(JwtClaimKeys.TOKEN_TYPE.getKey(), JwtClaimValues.ACCESS_TOKEN)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + accessTokenExpireMs))
                 .signWith(secretKey)

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
@@ -44,7 +44,7 @@ public class JwtUtil {
     public String createAccessJwt(Long userId, Role role) {
         return Jwts.builder()
                 .claim("userId", userId)
-                .claim("role", role.getValue())
+                .claim("role", role.name())
                 .claim("tokenType", ACCESS_TOKEN)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + accessTokenExpireMs))

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
@@ -32,23 +32,25 @@ public class JwtUtil {
     }
 
     public Long getUserId(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(JwtClaimKeys.USER_ID.getKey(), Long.class);
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(JwtClaimKey.USER_ID.getKey(), Long.class);
     }
 
     public Role getRole(String token) {
-        String role = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(JwtClaimKeys.ROLE.getKey(), String.class);
+        String role = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(JwtClaimKey.ROLE.getKey(), String.class);
         return Role.valueOf(role);
     }
 
-    public String getTokenType(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(JwtClaimKeys.TOKEN_TYPE.getKey(), String.class);
+    public JwtTokenType getTokenType(String token) {
+        String tokenType = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(JwtClaimKey.TOKEN_TYPE.getKey(), String.class);
+        return JwtTokenType.valueOf(tokenType);
+
     }
 
     public String createAccessJwt(Long userId, Role role) {
         return Jwts.builder()
-                .claim(JwtClaimKeys.USER_ID.getKey(), userId)
-                .claim(JwtClaimKeys.ROLE.getKey(), role.name())
-                .claim(JwtClaimKeys.TOKEN_TYPE.getKey(), JwtClaimValues.ACCESS_TOKEN)
+                .claim(JwtClaimKey.USER_ID.getKey(), userId)
+                .claim(JwtClaimKey.ROLE.getKey(), role.name())
+                .claim(JwtClaimKey.TOKEN_TYPE.getKey(), JwtTokenType.ACCESS_TOKEN)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + accessTokenExpireMs))
                 .signWith(secretKey)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,3 +93,9 @@ spring:
 logging:
   level:
     root: info
+
+findyou:
+  jwt:
+    access:
+      expire-ms: ${JWT_ACCESS_EXPIRE_MS}
+    secret-key : ${JWT_SECRET_KEY}

--- a/src/test/java/com/kuit/findyou/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/controller/AuthControllerTest.java
@@ -6,6 +6,8 @@ import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
 import com.kuit.findyou.global.common.response.BaseResponse;
+import com.kuit.findyou.global.jwt.util.JwtTokenType;
+import com.kuit.findyou.global.jwt.util.JwtUtil;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
@@ -18,7 +20,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -28,6 +29,9 @@ class AuthControllerTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
 
     @BeforeEach
     void setUp() {
@@ -59,6 +63,11 @@ class AuthControllerTest {
         assertThat(response.getData().userInfo()).isNotNull();
         assertThat(response.getData().userInfo().userId()).isEqualTo(user.getId());
         assertThat(response.getData().userInfo().nickname()).isEqualTo(user.getName());
+        assertThat(response.getData().userInfo().accessToken()).isNotNull();
+        String accessToken = response.getData().userInfo().accessToken();
+        assertThat(jwtUtil.getUserId(accessToken)).isEqualTo(user.getId());
+        assertThat(jwtUtil.getRole(accessToken)).isEqualTo(user.getRole());
+        assertThat(jwtUtil.getTokenType(accessToken)).isEqualTo(JwtTokenType.ACCESS_TOKEN);
     }
 
     private User createUser(String name, Role role, Long kakaoId){

--- a/src/test/java/com/kuit/findyou/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,79 @@
+package com.kuit.findyou.domain.auth.controller;
+
+import com.kuit.findyou.domain.auth.dto.KakaoLoginRequest;
+import com.kuit.findyou.domain.auth.dto.KakaoLoginResponse;
+import com.kuit.findyou.domain.user.model.Role;
+import com.kuit.findyou.domain.user.model.User;
+import com.kuit.findyou.domain.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class AuthControllerTest {
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    private AuthController authController;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @Transactional
+    void should_ReturnUserInfo_When_ExistingUserLogsIn(){
+        // given
+        final String NAME = "유저";
+        final Role ROLE = Role.USER;
+        final Long KAKAO_ID = 1234L;
+        User user = createUser(NAME, ROLE, KAKAO_ID);
+
+        // when
+        KakaoLoginResponse response = given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(new KakaoLoginRequest(KAKAO_ID))
+                .when()
+                .post("/api/v2/auth/login/kakao")
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(KakaoLoginResponse.class);
+
+        // then
+        assertThat(response.isFirstLogin()).isFalse();
+        assertThat(response.userInfo()).isNotNull();
+        assertThat(response.userInfo().userId()).isEqualTo(user.getId());
+        assertThat(response.userInfo().nickname()).isEqualTo(user.getName());
+    }
+
+    private User createUser(String name, Role role, Long kakaoId){
+        User build = User.builder()
+                .name(name)
+                .role(role)
+                .kakaoId(kakaoId)
+                .build();
+        return userRepository.save(build);
+    }
+}

--- a/src/test/java/com/kuit/findyou/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/service/AuthServiceTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
     @InjectMocks
-    private AuthService authService;
+    private AuthServiceImpl authService;
     @Mock
     private UserRepository userRepository;
     @Mock

--- a/src/test/java/com/kuit/findyou/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,76 @@
+package com.kuit.findyou.domain.auth.service;
+
+import com.kuit.findyou.domain.auth.dto.KakaoLoginRequest;
+import com.kuit.findyou.domain.auth.dto.KakaoLoginResponse;
+import com.kuit.findyou.domain.user.model.Role;
+import com.kuit.findyou.domain.user.model.User;
+import com.kuit.findyou.domain.user.repository.UserRepository;
+import com.kuit.findyou.global.jwt.util.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+    @InjectMocks
+    private AuthService authService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Test
+    void should_ReturnfirstLoginWithTrue_When_UserWithKakaoIdNotFound(){
+        // given
+        final Long KAKAO_ID = 1234L;
+        when(userRepository.findByKakaoId(any())).thenReturn(Optional.empty());
+
+        // when
+        KakaoLoginResponse response = authService.kakaoLogin(new KakaoLoginRequest(KAKAO_ID));
+
+        // then
+        assertThat(response.isFirstLogin()).isTrue();
+        assertThat(response.userInfo()).isNull();
+    }
+
+    @Test
+    void should_ReturnUserInfo_When_UserWithKakaoIdExists(){
+        // given
+        final Long KAKAO_ID = 1234L;
+        final String ACCESS_TOKEN = "accessToken";
+        final String NAME = "유저";
+
+        User user = mockUser(NAME, Role.USER, KAKAO_ID);
+        when(userRepository.findByKakaoId(KAKAO_ID)).thenReturn(Optional.of(user));
+        when(jwtUtil.createAccessJwt(user.getId(), user.getRole())).thenReturn(ACCESS_TOKEN);
+
+        // when
+        KakaoLoginResponse response = authService.kakaoLogin(new KakaoLoginRequest(KAKAO_ID));
+
+        // then
+        assertThat(response.isFirstLogin()).isFalse();
+        assertThat(response.userInfo()).isNotNull();
+        assertThat(response.userInfo().userId()).isEqualTo(user.getId());
+        assertThat(response.userInfo().accessToken()).isEqualTo(ACCESS_TOKEN);
+        assertThat(response.userInfo().nickname()).isEqualTo(NAME);
+    }
+
+    private User mockUser(String name, Role role, Long kakaoId){
+        User build = User.builder()
+                .id(1L)
+                .name(name)
+                .role(role)
+                .kakaoId(kakaoId)
+                .build();
+
+        return build;
+    }
+}

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -1,7 +1,9 @@
 package com.kuit.findyou.domain.report.controller;
 
 import com.kuit.findyou.domain.report.dto.request.ReportViewType;
+import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.global.common.util.TestInitializer;
+import com.kuit.findyou.global.jwt.util.JwtUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeAll;
@@ -31,16 +33,26 @@ class ReportControllerTest {
     @Autowired
     TestInitializer testInitializer;
 
+    @Autowired
+    JwtUtil jwtUtil;
+
+    User reportWriter;
+
     @BeforeAll
     void setUp() {
         RestAssured.port = port;
         testInitializer.initializeReportControllerTestData();
+        this.reportWriter = testInitializer.getReportWriter();
     }
 
     @Test
     @DisplayName("GET /api/v2/reports/protecting-reports/{id}: ProtectingReport 상세 조회 성공")
     void getProtectingReportDetail() {
+        // 작성자의 엑세스 토큰 생성
+        String accessToken = jwtUtil.createAccessJwt(reportWriter.getId(), reportWriter.getRole());
+
         given()
+                .header("Authorization", "Bearer " + accessToken)
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
@@ -72,7 +84,11 @@ class ReportControllerTest {
     @Test
     @DisplayName("GET /api/v2/reports/missing-reports/{id}: MissingReport 상세 조회 성공")
     void getMissingReportDetail() {
+        // 작성자의 엑세스 토큰 생성
+        String accessToken = jwtUtil.createAccessJwt(reportWriter.getId(), reportWriter.getRole());
+
         given()
+                .header("Authorization", "Bearer " + accessToken)
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
@@ -99,7 +115,11 @@ class ReportControllerTest {
     @Test
     @DisplayName("GET /api/v2/reports/witness-reports/{id}: WitnessReport 상세 조회 성공")
     void getWitnessReportDetail() {
+        // 작성자의 엑세스 토큰 생성
+        String accessToken = jwtUtil.createAccessJwt(reportWriter.getId(), reportWriter.getRole());
+
         given()
+                .header("Authorization", "Bearer " + accessToken)
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
@@ -123,7 +143,11 @@ class ReportControllerTest {
     @DisplayName("GET /api/v2/reports: 글 조회 성공")
     @Test
     void retrieveReportsWithFilters() {
+        // 작성자의 엑세스 토큰 생성
+        String accessToken = jwtUtil.createAccessJwt(reportWriter.getId(), reportWriter.getRole());
+
         given()
+                .header("Authorization", "Bearer " + accessToken)
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .param("type", ReportViewType.ALL)

--- a/src/test/java/com/kuit/findyou/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.kuit.findyou.domain.user.repository;
+
+import com.kuit.findyou.domain.user.model.Role;
+import com.kuit.findyou.domain.user.model.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class UserRepositoryTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @DisplayName("카카오 ID로 유저가 조회되는지 테스트")
+    @Test
+    void should_ReturnUser_When_UserWithKakaoIdExists(){
+        // given
+        final String NAME = "유저";
+        final Role ROLE = Role.USER;
+        final Long KAKAO_ID = 1234L;
+        User user = createUser(NAME, ROLE, KAKAO_ID);
+
+        // when
+        Optional<User> optUser = userRepository.findByKakaoId(KAKAO_ID);
+
+        // then
+        assertThat(optUser.isPresent()).isTrue();
+        User foundUser = optUser.get();
+        assertThat(foundUser.getName()).isEqualTo(NAME);
+        assertThat(foundUser.getRole()).isEqualTo(ROLE);
+        assertThat(foundUser.getKakaoId()).isEqualTo(KAKAO_ID);
+    }
+
+    private User createUser(String name, Role role, Long kakaoId){
+        User build = User.builder()
+                .name(name)
+                .role(role)
+                .kakaoId(kakaoId)
+                .build();
+        return userRepository.save(build);
+    }
+}

--- a/src/test/java/com/kuit/findyou/global/common/util/TestInitializer.java
+++ b/src/test/java/com/kuit/findyou/global/common/util/TestInitializer.java
@@ -27,10 +27,12 @@ public class TestInitializer {
     private final WitnessReportRepository witnessReportRepository;
     private final ReportImageRepository reportImageRepository;
     private final InterestReportRepository interestReportRepository;
+    private User reportWriter;
 
     @Transactional
     public void initializeReportControllerTestData() {
         User testUser = createTestUser();
+        reportWriter = testUser;
 
         ProtectingReport testProtectingReport = createTestProtectingReportWithImage(testUser);
         MissingReport testMissingReport = createTestMissingReportWithImage(testUser);
@@ -108,5 +110,9 @@ public class TestInitializer {
     private void createTestInterestReport(User user, Report report) {
         InterestReport interest = InterestReport.createInterestReport(user, report);
         interestReportRepository.save(interest);
+    }
+
+    public User getReportWriter(){
+        return this.reportWriter;
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,3 +13,9 @@ spring:
         show_sql: true
         highlight_sql: true
         dialect: org.hibernate.dialect.H2Dialect
+
+findyou:
+  jwt:
+    access:
+      expire-ms: 6000000
+    secret-key : secretkey1224secretkey1224secretkey1224secretkey1224


### PR DESCRIPTION
## Related issue 🛠
- closed #12

## Work Description 📝
- 로그인 API를 구현했습니다.
- 시큐리티 필터 체인에 필터를 추가하여서 JWT 기반 인가 로직을 구현했습니다. JWT 인가 필터에서는 토큰에 있는 사용자 정보로 UserDetails를 생성하도록 했습니다. DB 조회를 하지 않아서 성능이 더 좋기도 하고, 우리 서비스에서 사용자의 역할이 빈번히 바뀌지 않는다고 생각했기 때문입니다.
<img width="899" height="547" alt="image" src="https://github.com/user-attachments/assets/111b31d3-de8e-4898-8f34-7f5b789ef4b5" />

- 토큰 인가에 실패하면 entryPoint에서 커스텀 응답 형태로 실패를 응답합니다.
<img width="410" height="128" alt="image" src="https://github.com/user-attachments/assets/afad7a72-d5d0-4c1f-83d4-aca5511a6c26" />

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] 테스트 코드 작성

## To Reviewers 📢
1. 테스트 코드를 작성하려고 했는데, 저희 프로젝트에서 테스트 메서드의 작명은 어떻게 할지 논의를 못했어서 의견을 여쭤봅니다! 저는 전에 "given전제_when행위_then기대결과" 요런 느낌으로 하긴 했었거든요. 구글링 해보니 다양한 명명법이 있네요...
  - https://velog.io/@no1msh1217/%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BD%94%EB%93%9C-%EB%A9%94%EC%84%9C%EB%93%9C-%EC%9D%B4%EB%A6%84%EC%97%90-%EA%B4%80%ED%95%98%EC%97%AC
2. 저번처럼 LoginUserId 어노테이션을 Long 타입 변수에 붙이면 argument resolver로부터 userid를 얻을 수 있습니다!