### PR TITLE
[Feat] 글 조회 - (전체 조회/ 구조 동물 조회, 신고 동물 조회) 기능 구현

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -28,7 +28,7 @@ public class ReportController {
     private final ReportServiceFacade reportServiceFacade;
 
     @Operation(summary = "보호글 상세 조회 API", description = "보호글의 정보를 상세 조회하기 위한 API")
-    @GetMapping("/protecting/{reportId}")
+    @GetMapping("/protecting-reports/{reportId}")
     @CustomExceptionDescription(PROTECTING_REPORT_DETAIL)
     public BaseResponse<ProtectingReportDetailResponseDTO> getProtectingReportDetail(
             @PathVariable("reportId") Long reportId) {
@@ -38,7 +38,7 @@ public class ReportController {
     }
 
     @Operation(summary = "실종 신고글 상세 조회 API", description = "실종 신고글의 정보를 상세 조회하기 위한 API")
-    @GetMapping("/missing/{reportId}")
+    @GetMapping("/missing-reports/{reportId}")
     @CustomExceptionDescription(MISSING_REPORT_DETAIL)
     public BaseResponse<MissingReportDetailResponseDTO> getMissingReportDetail(
             @PathVariable("reportId") Long reportId) {
@@ -48,7 +48,7 @@ public class ReportController {
     }
 
     @Operation(summary = "목격 신고글 상세 조회 API", description = "목격 신고글의 정보를 상세 조회하기 위한 API")
-    @GetMapping("/witness/{reportId}")
+    @GetMapping("/witness-reports/{reportId}")
     @CustomExceptionDescription(WITNESS_REPORT_DETAIL)
     public BaseResponse<WitnessReportDetailResponseDTO> getWitnessReportDetail(
             @PathVariable("reportId") Long reportId) {

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -60,8 +60,8 @@ public class ReportController {
     }
 
     @Operation(summary = "글 조회 API (전체 / 구조 동물 / 신고 동물)", description = "글 조회를 위한 API - 전체 조회/구조 동물 조회/신고 동물 조회 시 쿼리 파라미터로 케이스를 구분")
-    @CustomExceptionDescription(RETRIEVE_REPORTS)
     @GetMapping
+    @CustomExceptionDescription(RETRIEVE_REPORTS)
     public BaseResponse<CardResponseDTO> retrieveReportsWithFilters(
             @RequestParam ReportViewType type,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -1,5 +1,7 @@
 package com.kuit.findyou.domain.report.controller;
 
+import com.kuit.findyou.domain.report.dto.request.ReportViewType;
+import com.kuit.findyou.domain.report.dto.response.CardResponseDTO;
 import com.kuit.findyou.domain.report.dto.response.MissingReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.dto.response.WitnessReportDetailResponseDTO;
@@ -11,10 +13,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.*;
 
@@ -56,4 +58,21 @@ public class ReportController {
         WitnessReportDetailResponseDTO detail = reportServiceFacade.getReportDetail(ReportTag.WITNESS, reportId, 1L);
         return BaseResponse.ok(detail);
     }
+
+    @Operation(summary = "글 조회 API (전체 / 구조 동물 / 신고 동물)", description = "글 조회를 위한 API - 전체 조회/구조 동물 조회/신고 동물 조회 시 쿼리 파라미터로 케이스를 구분")
+    @CustomExceptionDescription(RETRIEVE_REPORTS)
+    @GetMapping
+    public BaseResponse<CardResponseDTO> retrieveReportsWithFilters(
+            @RequestParam ReportViewType type,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(required = false) String species,
+            @RequestParam(required = false) String breeds,
+            @RequestParam(required = false) String address,
+            @RequestParam Long lastReportId
+    ) {
+        CardResponseDTO result = reportServiceFacade.retrieveReportsWithFilters(type, startDate, endDate, species, breeds, address, lastReportId, 1L);
+        return BaseResponse.ok(result);
+    }
+
 }

--- a/src/main/java/com/kuit/findyou/domain/report/dto/request/ReportViewType.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/request/ReportViewType.java
@@ -1,0 +1,17 @@
+package com.kuit.findyou.domain.report.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public enum ReportViewType {
+    ALL("전체 조회"),
+    PROTECTING("구조 동물 조회"),
+    REPORTING("신고 동물 조회");
+
+    private final String value;
+
+    ReportViewType(String value) {
+        this.value = value;
+    }
+}
+

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/Card.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/Card.java
@@ -1,0 +1,21 @@
+package com.kuit.findyou.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "글 카드 정보")
+public record Card(
+        @Schema(description = "글 Id", example = "1")
+        Long reportId,
+        @Schema(description = "썸네일 이미지 url", example = "image1.png")
+        String thumbnailImageUrl,
+        @Schema(description = "글 제목", example = "말티즈")
+        String title,
+        @Schema(description = "태그", example = "보호중")
+        String tag,
+        @Schema(description = "날짜 (발견 날짜/분실 날짜/목격 날짜)", example = "2025-07-01")
+        String date,
+        @Schema(description = "장소 (발견 장소/분실 장소/목격 장소)", example = "성산구 내동 628-1")
+        String location,
+        @Schema(description = "관심 여부", example = "true")
+        boolean interest
+) {}

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/CardResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/CardResponseDTO.java
@@ -6,7 +6,33 @@ import java.util.List;
 
 @Schema(description = "카드 목록 응답 DTO")
 public record CardResponseDTO(
-        @Schema(description = "카드 리스트", implementation = Card.class)
+        @Schema(
+                description = "카드 리스트",
+                type = "array",
+                implementation = Card.class,
+                example = """
+                        [
+                          {
+                            "reportId": 1,
+                            "thumbnailImageUrl": "image1.png",
+                            "title": "말티즈",
+                            "tag": "보호중",
+                            "date": "2025-07-01",
+                            "location": "성산구 내동 628-1",
+                            "interest": true
+                          },
+                          {
+                            "reportId": 2,
+                            "thumbnailImageUrl": "image2.png",
+                            "title": "푸들",
+                            "tag": "실종신고",
+                            "date": "2025-06-30",
+                            "location": "강남구 논현동",
+                            "interest": false
+                          }
+                        ]
+                        """
+        )
         List<Card> cards,
 
         @Schema(description = "마지막으로 조회된 글의 ID", example = "25")

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/CardResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/CardResponseDTO.java
@@ -1,0 +1,18 @@
+package com.kuit.findyou.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "카드 목록 응답 DTO")
+public record CardResponseDTO(
+        @Schema(description = "카드 리스트", implementation = Card.class)
+        List<Card> cards,
+
+        @Schema(description = "마지막으로 조회된 글의 ID", example = "25")
+        Long lastReportId,
+
+        @Schema(description = "마지막 페이지 여부", example = "false")
+        boolean isLast
+) {
+}

--- a/src/main/java/com/kuit/findyou/domain/report/dto/response/ReportProjection.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/response/ReportProjection.java
@@ -1,0 +1,12 @@
+package com.kuit.findyou.domain.report.dto.response;
+
+import java.time.LocalDate;
+
+public interface ReportProjection {
+    Long getReportId();
+    String getThumbnailImageUrl();
+    String getTitle();
+    String getTag();
+    LocalDate getDate();
+    String getAddress();
+}

--- a/src/main/java/com/kuit/findyou/domain/report/repository/InterestReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/InterestReportRepository.java
@@ -3,9 +3,22 @@ package com.kuit.findyou.domain.report.repository;
 
 import com.kuit.findyou.domain.report.model.InterestReport;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface InterestReportRepository extends JpaRepository<InterestReport, Long> {
 
     boolean existsByReport_IdAndUser_Id(Long reportId, Long userId);
+
+    @Query("""
+                SELECT ir.report.id
+                FROM InterestReport ir
+                WHERE ir.user.id = :userId
+                AND ir.report.id IN :reportIds
+            """)
+    List<Long> findInterestedReportIdsByUserIdAndReportIds(@Param("userId") Long userId, @Param("reportIds") List<Long> reportIds);
+
 
 }

--- a/src/main/java/com/kuit/findyou/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/ReportRepository.java
@@ -1,15 +1,58 @@
 package com.kuit.findyou.domain.report.repository;
 
+import com.kuit.findyou.domain.report.dto.response.ReportProjection;
 import com.kuit.findyou.domain.report.model.Report;
 import com.kuit.findyou.domain.report.model.ReportTag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
     List<Report> findByTag(ReportTag tag);
+
+    @Query("""
+                SELECT
+                    r.id AS reportId,
+                    (
+                        SELECT ri.imageUrl
+                        FROM ReportImage ri
+                        WHERE ri.report.id = r.id
+                        ORDER BY ri.id ASC
+                        LIMIT 1
+                    ) AS thumbnailImageUrl,
+                    r.breed AS title,
+                    r.tag AS tag,
+                    r.date AS date,
+                    r.address AS address
+                FROM Report r
+                WHERE r.id < :lastReportId
+                  AND (:tags IS NULL OR r.tag IN :tags)
+                  AND (:startDate IS NULL OR r.date >= :startDate)
+                  AND (:endDate IS NULL OR r.date <= :endDate)
+                  AND (:species IS NULL OR r.species LIKE CONCAT('%', :species, '%'))
+                  AND (:breeds IS NULL OR r.breed IN :breeds)
+                  AND (:address IS NULL OR r.address LIKE CONCAT('%', :address, '%'))
+                ORDER BY r.id DESC
+            """)
+    Slice<ReportProjection> findReportsWithFilters(
+            @Param("tags") List<ReportTag> tags,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            @Param("species") String species,
+            @Param("breeds") List<String> breeds,
+            @Param("address") String address,
+            @Param("lastReportId") Long lastReportId,
+            Pageable pageable
+    );
+
+
 }
 

--- a/src/main/java/com/kuit/findyou/domain/report/service/detail/ReportDetailServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/detail/ReportDetailServiceImpl.java
@@ -8,11 +8,13 @@ import com.kuit.findyou.domain.report.strategy.ReportDetailStrategy;
 import com.kuit.findyou.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 
-@Service
 @RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
 public class ReportDetailServiceImpl implements ReportDetailService {
 
     private final InterestReportRepository interestReportRepository;

--- a/src/main/java/com/kuit/findyou/domain/report/service/facade/ReportServiceFacade.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/facade/ReportServiceFacade.java
@@ -1,11 +1,16 @@
 package com.kuit.findyou.domain.report.service.facade;
 
+import com.kuit.findyou.domain.report.dto.request.ReportViewType;
+import com.kuit.findyou.domain.report.dto.response.CardResponseDTO;
 import com.kuit.findyou.domain.report.model.ReportTag;
 import com.kuit.findyou.domain.report.service.detail.ReportDetailService;
+import com.kuit.findyou.domain.report.service.retrieve.ReportRetrieveService;
 import com.kuit.findyou.domain.user.repository.UserRepository;
 import com.kuit.findyou.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
 
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
 
@@ -14,6 +19,7 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 public class ReportServiceFacade {
 
     private final ReportDetailService reportDetailService;
+    private final ReportRetrieveService reportRetrieveService;
     private final UserRepository userRepository;
 
     public <DTO_TYPE> DTO_TYPE getReportDetail(ReportTag tag, Long reportId, Long userId) {
@@ -22,6 +28,23 @@ public class ReportServiceFacade {
         }
 
         return reportDetailService.getReportDetail(tag, reportId, userId);
+    }
+
+    public CardResponseDTO retrieveReportsWithFilters(
+            ReportViewType reportViewType,
+            LocalDate startDate,
+            LocalDate endDate,
+            String species,
+            String breeds,
+            String location,
+            Long lastReportId,
+            Long userId
+    ) {
+        if (!userRepository.existsById(userId)) {
+            throw new CustomException(USER_NOT_FOUND);
+        }
+
+        return reportRetrieveService.retrieveReportsWithFilters(reportViewType, startDate, endDate, species, breeds, location, lastReportId, userId);
     }
 }
 

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ReportRetrieveService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ReportRetrieveService.java
@@ -1,6 +1,19 @@
 package com.kuit.findyou.domain.report.service.retrieve;
 
+import com.kuit.findyou.domain.report.dto.response.CardResponseDTO;
+import com.kuit.findyou.domain.report.model.ReportTag;
+
+import java.time.LocalDate;
+
 public interface ReportRetrieveService {
+
+    public CardResponseDTO retrieveReportsWithFilters(Long lastReportId,
+                                                      ReportTag reportTag,
+                                                      LocalDate startDate,
+                                                      LocalDate endDate,
+                                                      String species,
+                                                      String breeds,
+                                                      String location);
 
 
 }

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ReportRetrieveService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ReportRetrieveService.java
@@ -1,19 +1,20 @@
 package com.kuit.findyou.domain.report.service.retrieve;
 
+import com.kuit.findyou.domain.report.dto.request.ReportViewType;
 import com.kuit.findyou.domain.report.dto.response.CardResponseDTO;
-import com.kuit.findyou.domain.report.model.ReportTag;
 
 import java.time.LocalDate;
 
 public interface ReportRetrieveService {
 
-    public CardResponseDTO retrieveReportsWithFilters(Long lastReportId,
-                                                      ReportTag reportTag,
-                                                      LocalDate startDate,
-                                                      LocalDate endDate,
-                                                      String species,
-                                                      String breeds,
-                                                      String location);
+    CardResponseDTO retrieveReportsWithFilters(ReportViewType reportViewType,
+                                               LocalDate startDate,
+                                               LocalDate endDate,
+                                               String species,
+                                               String breeds,
+                                               String location,
+                                               Long lastReportId,
+                                               Long userId);
 
 
 }

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ReportRetrieveService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ReportRetrieveService.java
@@ -1,0 +1,6 @@
+package com.kuit.findyou.domain.report.service.retrieve;
+
+public interface ReportRetrieveService {
+
+
+}

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ReportRetrieveServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ReportRetrieveServiceImpl.java
@@ -7,10 +7,8 @@ import com.kuit.findyou.domain.report.dto.response.ReportProjection;
 import com.kuit.findyou.domain.report.model.ReportTag;
 import com.kuit.findyou.domain.report.repository.InterestReportRepository;
 import com.kuit.findyou.domain.report.repository.ReportRepository;
-import com.kuit.findyou.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,7 +51,7 @@ public class ReportRetrieveServiceImpl implements ReportRetrieveService {
                 tags, startDate, endDate, species, breedList, location, lastReportId, PageRequest.of(0, 20)
         );
 
-        List<Card> reportList = convertReportProjectionSliceToCardVOList(reportSlice.getContent(), userId);
+        List<Card> reportList = convertReportProjectionSliceToCardList(reportSlice.getContent(), userId);
 
         // 마지막 글의 ID == 다음 요청으로 전달할 Cursor 값
         Long nextCursor = findLastReportId(reportList);
@@ -70,7 +68,7 @@ public class ReportRetrieveServiceImpl implements ReportRetrieveService {
                 .toList();
     }
 
-    private List<Card> convertReportProjectionSliceToCardVOList(List<ReportProjection> reportSlice, Long userId) {
+    private List<Card> convertReportProjectionSliceToCardList(List<ReportProjection> reportSlice, Long userId) {
         List<Long> reportIds = reportSlice.stream()
                 .map(ReportProjection::getReportId)
                 .toList();

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ReportRetrieveServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ReportRetrieveServiceImpl.java
@@ -1,0 +1,103 @@
+package com.kuit.findyou.domain.report.service.retrieve;
+
+import com.kuit.findyou.domain.report.dto.request.ReportViewType;
+import com.kuit.findyou.domain.report.dto.response.Card;
+import com.kuit.findyou.domain.report.dto.response.CardResponseDTO;
+import com.kuit.findyou.domain.report.dto.response.ReportProjection;
+import com.kuit.findyou.domain.report.model.ReportTag;
+import com.kuit.findyou.domain.report.repository.InterestReportRepository;
+import com.kuit.findyou.domain.report.repository.ReportRepository;
+import com.kuit.findyou.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class ReportRetrieveServiceImpl implements ReportRetrieveService {
+
+    private final InterestReportRepository interestReportRepository;
+    private final ReportRepository reportRepository;
+
+    @Override
+    public CardResponseDTO retrieveReportsWithFilters(
+            ReportViewType reportViewType,
+            LocalDate startDate,
+            LocalDate endDate,
+            String species,
+            String breeds,
+            String location,
+            Long lastReportId,
+            Long userId
+    ) {
+        List<String> breedList = parseBreeds(breeds);
+
+        // ReportViewType에 따라 필터링할 tag 목록 생성
+        List<ReportTag> tags = switch (reportViewType) {
+            case ALL -> null;
+            case PROTECTING -> List.of(ReportTag.PROTECTING);
+            case REPORTING -> List.of(ReportTag.MISSING, ReportTag.WITNESS);
+        };
+
+        Slice<ReportProjection> reportSlice = reportRepository.findReportsWithFilters(
+                tags, startDate, endDate, species, breedList, location, lastReportId, PageRequest.of(0, 20)
+        );
+
+        List<Card> reportList = convertReportProjectionSliceToCardVOList(reportSlice.getContent(), userId);
+
+        // 마지막 글의 ID == 다음 요청으로 전달할 Cursor 값
+        Long nextCursor = findLastReportId(reportList);
+
+        return new CardResponseDTO(reportList, nextCursor, !reportSlice.hasNext());
+    }
+
+
+    private List<String> parseBreeds(String breeds) {
+        if (breeds == null || breeds.isBlank()) return null;
+        return Arrays.stream(breeds.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+
+    private List<Card> convertReportProjectionSliceToCardVOList(List<ReportProjection> reportSlice, Long userId) {
+        List<Long> reportIds = reportSlice.stream()
+                .map(ReportProjection::getReportId)
+                .toList();
+
+        // 관심 있는 reportId만 조회
+        Set<Long> interestIds = new HashSet<>(
+                interestReportRepository.findInterestedReportIdsByUserIdAndReportIds(userId, reportIds)
+        );
+
+        return reportSlice.stream()
+                .map(p -> new Card(
+                        p.getReportId(),
+                        p.getThumbnailImageUrl(),
+                        p.getTitle(),
+                        ReportTag.valueOf(p.getTag()).getValue(),
+                        p.getDate().toString(),
+                        p.getAddress(),
+                        interestIds.contains(p.getReportId())
+                ))
+                .toList();
+    }
+
+
+    private Long findLastReportId(List<Card> reportList) {
+        if (reportList.isEmpty()) return -1L;
+
+        return reportList.get(reportList.size() - 1).reportId();
+    }
+}
+

--- a/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
@@ -9,8 +9,10 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
@@ -19,28 +21,40 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 @Slf4j
 @RestControllerAdvice
 public class GlobalControllerAdvice {
-    // 잘못된 요청일 경우
+
+    /**
+     * 숫자/boolean 등의 타입이 일치하지 않는 경우 발생하는 Hibernate 예외 처리
+     * 주로 잘못된 파라미터 변환 시 발생 (ex. boolean 필드에 문자열 전달)
+     */
     @ExceptionHandler(TypeMismatchException.class)
     public BaseErrorResponse handle_TypeMismatchException(TypeMismatchException e){
         log.error("[handle_TypeMismatchException]", e);
         return new BaseErrorResponse(BAD_REQUEST);
     }
 
-    // 요청한 api가 없을 경우
+    /**
+     * 존재하지 않는 API 경로로 요청했을 때 발생 (404 Not Found)
+     */
     @ExceptionHandler(NoHandlerFoundException.class)
     public BaseErrorResponse handle_NoHandlerFoundException(NoHandlerFoundException e){
         log.error("[handle_NoHandlerFoundException]", e);
         return new BaseErrorResponse(API_NOT_FOUND);
     }
 
-    // 런타임 오류가 발생한 경우
+    /**
+     * 처리되지 않은 런타임 예외를 전역적으로 처리
+     * 서버 내부 오류(500 Internal Server Error) 응답 반환
+     */
     @ExceptionHandler(RuntimeException.class)
     public BaseErrorResponse handle_RuntimeException(RuntimeException e) {
         log.error("[handle_RuntimeException]", e);
         return new BaseErrorResponse(INTERNAL_SERVER_ERROR);
     }
 
-    // 요청에 필요한 인자가 없는 경우
+    /**
+     * @Valid 또는 @Validated를 통해 DTO 필드 유효성 검사에 실패한 경우 처리
+     * (e.g., 필수값 누락, 길이 초과 등)
+     */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public BaseErrorResponse handle_MethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("[handle_MethodArgumentNotValidException]", e);
@@ -49,7 +63,36 @@ public class GlobalControllerAdvice {
         return new BaseErrorResponse(BAD_REQUEST, defaultMessage);
     }
 
-    // 커스텀 예외의 경우
+    /**
+     * @RequestParam 필드가 아예 전달되지 않은 경우 처리
+     * (e.g., 필수 쿼리 파라미터 누락)
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public BaseErrorResponse handle_MissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        log.error("[handle_MissingServletRequestParameterException]", e);
+        String message = String.format("필수 요청 파라미터 '%s'가 누락되었습니다.", e.getParameterName());
+        return new BaseErrorResponse(BAD_REQUEST, message);
+    }
+
+    /**
+     * @RequestParam, @PathVariable 등에서 enum/숫자 등의 타입 변환이 실패한 경우 처리
+     * (e.g., 잘못된 enum 값, 숫자 자리에 문자열 입력 등)
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public BaseErrorResponse handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+        log.error("[handleMethodArgumentTypeMismatch]", e);
+
+        String name = e.getName();  // 파라미터 이름
+        String value = e.getValue() != null ? e.getValue().toString() : "null";
+        String message = String.format("잘못된 '%s' 파라미터 값입니다. 입력값: '%s'", name, value);
+
+        return new BaseErrorResponse(BAD_REQUEST, message);
+    }
+
+    /**
+     * 프로젝트 내부에서 발생한 CustomException 처리
+     * 각 예외가 담고 있는 커스텀 응답 코드와 메시지를 그대로 반환
+     */
     @ExceptionHandler(CustomException.class)
     public BaseErrorResponse handle_CustomException(CustomException e) {
         log.error("[handle_CustomException]", e);

--- a/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
@@ -28,6 +28,10 @@ public enum SwaggerResponseDescription {
     WITNESS_REPORT_DETAIL(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
             WITNESS_REPORT_NOT_FOUND
+    ))),
+
+    RETRIEVE_REPORTS(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
     )));
 
     private final Set<BaseExceptionResponseStatus> exceptionResponseStatusSet;


### PR DESCRIPTION
## Related issue 🛠
- closed #17 

## Work Description 📝
- 글 조회 기능을 구현하였습니다.

### 인터페이스 기반 Projection 적용
이전에 언급한 바 있듯이, ReportRepository 에서 아무런 조건 없이 findAll() 메서드를 호출하게되면, 오직 Report 엔티티에 존재하는 데이터만을 끌어오는 것이 아니라, 상속 관계 JOINED 전략에 의해 하위 클래스들인 ProtectingReport, WitnessReport, MissingReport 의 정보까지 자동 JOIN 을 통해 모두 조회해오는 현상이 존재했습니다.

하지만 전체 조회/구조 동물 조회/신고 동물 조회 로직에서는 오직 글의 요약 정보 ( = 카드 정보) 만이 필요하고 이 정보들은 오직 Report 엔티티에 존재하는 데이터만으로 구성됩니다.
그에 따라 불필요한 JOIN 을 방지하기 위해 Projection 이라는 기능을 도입했습니다. Projection은 필요한 필드만을 선택적으로 조회할 수 있도록 도와주는 JPA의 기능이라고 합니다. 특히 인터페이스 기반 Projection을 사용하면, JPQL이나 Native Query를 작성하지 않고도 특정 필드 집합만을 조회하는 쿼리를 자동 생성해주어서 편리하고 성능상에 ReportImage 를 끌어오는 과정에서 N+1 문제도 방지할 수 있을 것 같아 이처럼 구현하게되었습니다.

<img width="389" height="176" alt="스크린샷 2025-07-15 오전 1 17 54" src="https://github.com/user-attachments/assets/7c54dd7c-b604-4ad4-a773-6d6a73c94cd7" />

### Projection 기능 재사용 가능성
관심글 조회 / 최근 본 글 조회 기능 화면 등은 전체 조회/구조 동물 조회/신고 동물 조회 와 사실상 UI 가 동일합니다. 따라서 그 때에도 현재 만들어둔 ReportProjection 을 활용하는 것이 가능할 것이라 판단됩니다.

### ReportViewType enum
하나의 API 를 통해 3가지 기능을 모두 커버하도록 구현하였습니다. 쿼리 파라미터 -> type 을 통해 전체 조회/구조 동물 조회/신고 동물 조회 를 구분하도록 하였습니다.
이 구분을 위해서 ReportViewType 이라는 Enum 을 하나 만들어두었습니다.

전체 조회 - ALL
구조 동물 조회 - PROTECTING
신고 동물 조회 - REPORTING

각각으로 ENUM 을 만들어두어 type 별로 서로 다른 데이터들을 조회할 수 있도록 구현하였습니다.

<img width="405" height="265" alt="스크린샷 2025-07-15 오전 1 18 54" src="https://github.com/user-attachments/assets/f825489e-3344-47b8-a45c-6e7edf6e2da7" />

### 알아두면 좋을 것 같은 점

이건 Projection 이외의 내용인데, 전체 조회/구조 동물 조회/신고 동물 조회 + 관심글/최근 본 글 조회 기능들을 구현할 때 저희는 무한스크롤을 위해 페이징을 적용하고 있습니다.
다만 이 때 각각의 정보들을 Report 엔티티로부터 조회해올 때, 해당 Report 와 연관된 하나의 썸네일을 얻어와야하는데, 이 과정에서 코드를 효율적으로 짜지 못하면 N+1 문제가 발생할 수 있다 생각됩니다.

20개의 Report 를 한 번에 조회 + 각각의 Report 별로 썸네일 이미지를 얻어오기 위해서 report.getReportImage().get(0); 와 같은 로직을 활용한다고 가정했을 때, getReportImage() 메서드를 호출하는 경우 지연 로딩에 의해 1번의 쿼리가 더 나가게될 수 있습니다.
즉 20개의 Report 각각에 대해 getReportImage() 메서드가 호출된다고 가정할 경우 총 1 + 20 번의 쿼리가 나가 N+1 문제가 발생하게 되는 것입니다.

그럼 reportImage 까지 fetch join 을 사용해서 한 번에 끌어오면 해결되는 것 아닌가? 하는 생각이 들 수 있는데, 페이징을 수행할 때에는 fetch join 을 사용해서는 안된다고 합니다. 20개의 Report 를 끌어왔다고 가정하고 각각의 Report 마다 5개의 이미지가 연관 관계로 걸려있는 상황이라고 가정해봅시다. 

이 때 fetch join 을 활용해서 20개의 Report 를 이미지와 함께 조회해올 경우 총 20 * 5 = 100 개의 row 가 생성되게 됩니다.
그러다보니 JPA 는 이 100개의 row 중에서 20개를 끌어와야하는 것인지, 아니면 그냥 Report 기반으로 20개를 끌어와야하는 것인지 제대로 판단하지 못해 LIMIT 쿼리를 날리지 않게 됩니다. 즉 데이터베이스 레벨에서의 LIMIT 을 통한 페이징을 포기하고 모든 데이터를 메모리로 끌어온 후 애플리케이션 레벨에서 페이징을 처리하게 됩니다.
즉 만약 전체 Report 개수가 10000개라고 가정하면, 이 10000개 + 각 Report 별 이미지 데이터들을 전부 다 끌어온 뒤, 애플리케이션 레벨에서 Report 의 중복을 제거한 후 20개의 데이터를 페이징 해오기 때문에 엄청난 성능 저하가 발생합니다.

반면에 제가 지금 구현한 방식인 인터페이스 기반 Projection 을 활용하면 서브 쿼리를 활용하여 fetch join 을 하지 않으면서, 한 번에 썸네일 이미지까지 조회해올 수 있어서 위와 같은 문제는 발생하지 않습니다.

<img width="304" height="289" alt="스크린샷 2025-07-15 오전 1 13 20" src="https://github.com/user-attachments/assets/c1e94601-b039-4af1-8195-d6d68426f6bd" />

따라서 추후 무한스크롤이 필요하고 글의 요약 정보(카드 정보)를 보여주어야하는 경우 Projection 을 잘 쓰면 좋을 것 같습니다~

## Screenshot 📸
<img width="600" height="544" alt="스크린샷 2025-07-15 오전 1 14 45" src="https://github.com/user-attachments/assets/f3e0cdfc-6d16-43b3-949b-6869e213ee6f" />


## Uncompleted Tasks 😅
- [ ] 테스트 코드 작성

## To Reviewers 📢
테스트 코드도 한 번에 작성해서 올릴까 하다가 제가 앞서 테스트 코드 관련 PR 을 올려뒀어서, 해당 PR이 머지된 이후에 거기서부터 테스트 코드를 작성하면 좋을 것 같아 우선 기능 구현 위주로 PR을 올려두겠습니다!