### PR TITLE
[Test] 글 조회 - (전체 조회/ 구조 동물 조회, 신고 동물 조회) 테스트 코드 구현

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/notification/repository/NotificationHistoryRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/notification/repository/NotificationHistoryRepository.java
@@ -1,8 +1,7 @@
 package com.kuit.findyou.domain.notification.repository;
 
+import com.kuit.findyou.domain.notification.model.NotificationHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import javax.management.Notification;
-
-public interface NotificationHistoryRepository extends JpaRepository<Notification, Long> {
+public interface NotificationHistoryRepository extends JpaRepository<NotificationHistory, Long> {
 }

--- a/src/main/java/com/kuit/findyou/domain/report/model/MissingReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/MissingReport.java
@@ -94,7 +94,11 @@ public class MissingReport extends Report {
                 .latitude(latitude)
                 .longitude(longitude)
                 .build();
-        user.addReport(report); // 양방향 연관관계 설정
+
+        if (user != null) {
+            user.addReport(report); // 양방향 연관관계 설정
+        }
+
         return report;
     }
 

--- a/src/main/java/com/kuit/findyou/domain/report/model/MissingReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/MissingReport.java
@@ -56,7 +56,7 @@ public class MissingReport extends Report {
                           String reporterName, String reporterTel, String landmark, BigDecimal latitude,
                           BigDecimal longitude) {
         super(null, breed, species, tag, date, address, user, new ArrayList<>(),
-                new ArrayList<>(), new ArrayList<>());
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
         this.sex = sex;
         this.rfid = rfid;
         this.age = age;

--- a/src/main/java/com/kuit/findyou/domain/report/model/ProtectingReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/ProtectingReport.java
@@ -72,7 +72,7 @@ public class ProtectingReport extends Report {
                              String careTel, String authority, BigDecimal latitude,
                             BigDecimal longitude) {
         super(null, breed, species, tag, date, address, user, new ArrayList<>(),
-                new ArrayList<>(), new ArrayList<>());
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
         this.sex = sex;
         this.age = age;
         this.weight = weight;

--- a/src/main/java/com/kuit/findyou/domain/report/model/ProtectingReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/ProtectingReport.java
@@ -124,8 +124,9 @@ public class ProtectingReport extends Report {
                 .longitude(longitude)
                 .build();
 
-        // 양방향 연관관계 설정
-        user.addReport(report);
+        if (user != null) {
+            user.addReport(report); // 양방향 연관관계 설정
+        }
 
         return report;
     }

--- a/src/main/java/com/kuit/findyou/domain/report/model/WitnessReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/WitnessReport.java
@@ -69,7 +69,11 @@ public class WitnessReport extends Report {
                 .latitude(latitude)
                 .longitude(longitude)
                 .build();
-        user.addReport(report); // 양방향 연관관계 설정
+
+        if (user != null) {
+            user.addReport(report); // 양방향 연관관계 설정
+        }
+
         return report;
     }
 

--- a/src/main/java/com/kuit/findyou/domain/report/model/WitnessReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/WitnessReport.java
@@ -42,7 +42,7 @@ public class WitnessReport extends Report {
                           String reporterName, String landmark, BigDecimal latitude,
                           BigDecimal longitude) {
         super(null, breed, species, tag, date, address, user, new ArrayList<>(),
-                new ArrayList<>(), new ArrayList<>());
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
         this.furColor = furColor;
         this.significant = significant;
         this.reporterName = reporterName;

--- a/src/main/java/com/kuit/findyou/domain/report/repository/InterestReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/InterestReportRepository.java
@@ -10,7 +10,16 @@ import java.util.List;
 
 public interface InterestReportRepository extends JpaRepository<InterestReport, Long> {
 
-    boolean existsByReport_IdAndUser_Id(Long reportId, Long userId);
+
+    @Query(value = "SELECT EXISTS (" +
+            "SELECT 1 FROM interest_reports " +
+            "WHERE report_id = :reportId " +
+            "AND user_id = :userId " +
+            "AND status = 'Y'" +
+            ")", nativeQuery = true)
+    boolean existsByReportIdAndUserId(@Param("reportId") Long reportId,
+                                      @Param("userId") Long userId);
+
 
     @Query("""
                 SELECT ir.report.id

--- a/src/main/java/com/kuit/findyou/domain/report/service/detail/ReportDetailServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/detail/ReportDetailServiceImpl.java
@@ -26,7 +26,7 @@ public class ReportDetailServiceImpl implements ReportDetailService {
                 (ReportDetailStrategy<REPORT_TYPE, DTO_TYPE>) strategies.get(tag);
 
         REPORT_TYPE report = strategy.getReport(reportId);
-        boolean interest = interestReportRepository.existsByReport_IdAndUser_Id(report.getId(), userId);
+        boolean interest = interestReportRepository.existsByReportIdAndUserId(report.getId(), userId);
 
         return strategy.getDetail(report, interest);
     }

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -35,13 +35,13 @@ class ReportControllerTest {
     }
 
     @Test
-    @DisplayName("GET /api/v2/reports/protecting/{id}: ProtectingReport 상세 조회 성공")
+    @DisplayName("GET /api/v2/reports/protecting-reports/{id}: ProtectingReport 상세 조회 성공")
     void getProtectingReportDetail() {
         given()
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
-                .get("/api/v2/reports/protecting/1")
+                .get("/api/v2/reports/protecting-reports/1")
                 .then()
                 .statusCode(200)
                 .body("data.imageUrls[0]", equalTo("https://img.com/1.png"))
@@ -67,13 +67,13 @@ class ReportControllerTest {
     }
 
     @Test
-    @DisplayName("GET /api/v2/reports/missing/{id}: MissingReport 상세 조회 성공")
+    @DisplayName("GET /api/v2/reports/missing-reports/{id}: MissingReport 상세 조회 성공")
     void getMissingReportDetail() {
         given()
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
-                .get("/api/v2/reports/missing/2")
+                .get("/api/v2/reports/missing-reports/2")
                 .then()
                 .statusCode(200)
                 .body("data.imageUrls[0]", equalTo("https://img.com/missing.png"))
@@ -94,13 +94,13 @@ class ReportControllerTest {
     }
 
     @Test
-    @DisplayName("GET /api/v2/reports/witness/{id}: WitnessReport 상세 조회 성공")
+    @DisplayName("GET /api/v2/reports/witness-reports/{id}: WitnessReport 상세 조회 성공")
     void getWitnessReportDetail() {
         given()
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
-                .get("/api/v2/reports/witness/3")
+                .get("/api/v2/reports/witness-reports/3")
                 .then()
                 .statusCode(200)
                 .body("data.imageUrls[0]", equalTo("https://img.com/witness.png"))

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -1,5 +1,6 @@
 package com.kuit.findyou.domain.report.controller;
 
+import com.kuit.findyou.domain.report.dto.request.ReportViewType;
 import com.kuit.findyou.global.common.util.TestInitializer;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -13,6 +14,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
+
+import java.time.LocalDate;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
@@ -116,4 +119,43 @@ class ReportControllerTest {
                 .body("data.witnessDate", equalTo("2024-08-10"))
                 .body("data.interest", equalTo(true));
     }
+
+    @DisplayName("GET /api/v2/reports: 글 조회 성공")
+    @Test
+    void retrieveReportsWithFilters() {
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .param("type", ReportViewType.ALL)
+                .param("lastReportId", Long.MAX_VALUE)
+        .when()
+                .get("/api/v2/reports")
+        .then()
+                .statusCode(200)
+                .body("data.cards[0].reportId", equalTo(3))
+                .body("data.cards[0].thumbnailImageUrl", equalTo("https://img.com/witness.png"))
+                .body("data.cards[0].title", equalTo("진돗개"))
+                .body("data.cards[0].tag", equalTo("목격신고"))
+                .body("data.cards[0].date", equalTo("2024-08-10"))
+                .body("data.cards[0].location", equalTo("부산시 해운대구"))
+                .body("data.cards[0].interest", equalTo(true))
+                .body("data.cards[1].reportId", equalTo(2))
+                .body("data.cards[1].thumbnailImageUrl", equalTo("https://img.com/missing.png"))
+                .body("data.cards[1].title", equalTo("포메라니안"))
+                .body("data.cards[1].tag", equalTo("실종신고"))
+                .body("data.cards[1].date", equalTo("2024-10-05"))
+                .body("data.cards[1].location", equalTo("서울시 강남구"))
+                .body("data.cards[1].interest", equalTo(true))
+                .body("data.cards[2].reportId", equalTo(1))
+                .body("data.cards[2].thumbnailImageUrl", equalTo("https://img.com/1.png"))
+                .body("data.cards[2].title", equalTo("믹스견"))
+                .body("data.cards[2].tag", equalTo("보호중"))
+                .body("data.cards[2].date", equalTo(LocalDate.now().toString()))
+                .body("data.cards[2].location", equalTo("서울"))
+                .body("data.cards[2].interest", equalTo(true))
+                .body("data.lastReportId", equalTo(1))
+                .body("data.isLast", equalTo(true));
+    }
+
+
 }

--- a/src/test/java/com/kuit/findyou/domain/report/repository/InterestReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/InterestReportRepositoryTest.java
@@ -82,8 +82,8 @@ class InterestReportRepositoryTest {
         Long userId = testUser.getId();
 
         // when
-        boolean exists = interestReportRepository.existsByReport_IdAndUser_Id(reportId, userId);
-        boolean notExists = interestReportRepository.existsByReport_IdAndUser_Id(999L, userId);
+        boolean exists = interestReportRepository.existsByReportIdAndUserId(reportId, userId);
+        boolean notExists = interestReportRepository.existsByReportIdAndUserId(999L, userId);
 
         // then
         assertThat(exists).isTrue();

--- a/src/test/java/com/kuit/findyou/domain/report/repository/InterestReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/InterestReportRepositoryTest.java
@@ -1,0 +1,152 @@
+package com.kuit.findyou.domain.report.repository;
+
+import com.kuit.findyou.domain.report.model.*;
+import com.kuit.findyou.domain.user.model.Role;
+import com.kuit.findyou.domain.user.model.User;
+import com.kuit.findyou.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@DataJpaTest
+@Transactional
+@ActiveProfiles("test")
+class InterestReportRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private InterestReportRepository interestReportRepository;
+
+    @Autowired
+    private ReportRepository reportRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private User testUser;
+    private MissingReport missingReport;
+    private WitnessReport witnessReport;
+    private ProtectingReport protectingReport;
+
+    @BeforeEach
+    void init() {
+        testUser = userRepository.save(
+                User.builder()
+                        .name("홍길동")
+                        .profileImageUrl("http://example.com/profile.png")
+                        .kakaoId(123131231231L)
+                        .role(Role.USER)
+                        .build()
+        );
+        createTestReports();
+    }
+
+    @Test
+    @DisplayName("관심글 저장 및 전체 조회 테스트")
+    void saveAndFindAll() {
+        // given
+        saveAllInterestReports();
+
+        // when
+        em.flush();
+        em.clear();
+        List<InterestReport> all = interestReportRepository.findAll();
+
+        // then
+        assertThat(all).hasSize(3);
+        assertThat(all).extracting(ir -> ir.getReport().getTag())
+                .containsExactlyInAnyOrder(ReportTag.MISSING, ReportTag.WITNESS, ReportTag.PROTECTING);
+    }
+
+    @Test
+    @DisplayName("관심글 존재 여부 테스트")
+    void existsByReportIdAndUserId() {
+        // given
+        interestReportRepository.save(InterestReport.createInterestReport(testUser, missingReport));
+        Long reportId = missingReport.getId();
+        Long userId = testUser.getId();
+
+        // when
+        boolean exists = interestReportRepository.existsByReport_IdAndUser_Id(reportId, userId);
+        boolean notExists = interestReportRepository.existsByReport_IdAndUser_Id(999L, userId);
+
+        // then
+        assertThat(exists).isTrue();
+        assertThat(notExists).isFalse();
+    }
+
+    @Test
+    @DisplayName("특정 유저의 관심글 중 일부 ID 조회 테스트")
+    void findInterestedReportIdsByUserIdAndReportIds() {
+        // given
+        saveAllInterestReports();
+
+        List<Long> allReportIds = List.of(
+                missingReport.getId(),
+                witnessReport.getId(),
+                protectingReport.getId(),
+                999L // 존재하지 않는 Report ID
+        );
+
+        // when
+        List<Long> interestedIds = interestReportRepository.findInterestedReportIdsByUserIdAndReportIds(testUser.getId(), allReportIds);
+
+        // then
+        assertThat(interestedIds).hasSize(3);
+        assertThat(interestedIds)
+                .containsExactlyInAnyOrder(
+                        missingReport.getId(),
+                        witnessReport.getId(),
+                        protectingReport.getId()
+                )
+                .doesNotContain(999L);
+    }
+
+    private void saveAllInterestReports() {
+        interestReportRepository.save(InterestReport.createInterestReport(testUser, missingReport));
+        interestReportRepository.save(InterestReport.createInterestReport(testUser, witnessReport));
+        interestReportRepository.save(InterestReport.createInterestReport(testUser, protectingReport));
+    }
+
+    private void createTestReports() {
+        missingReport = MissingReport.createMissingReport(
+                "골든 리트리버", "개", ReportTag.MISSING, LocalDate.now().minusDays(5),
+                "서울시 강남구", testUser, Sex.M, "RFID123456", "3살", "25kg", "황금색", "목에 빨간 목걸이",
+                "김철수", "010-1234-5678", "강남역 근처",
+                new BigDecimal("37.497952"), new BigDecimal("127.027619")
+        );
+
+        witnessReport = WitnessReport.createWitnessReport(
+                "믹스견", "개", ReportTag.WITNESS, LocalDate.now().minusDays(3),
+                "서울시 서초구", testUser, "검은색", "오른쪽 다리 절뚝임", "이영희", "서초역 2번 출구",
+                new BigDecimal("37.483569"), new BigDecimal("127.032455")
+        );
+
+        protectingReport = ProtectingReport.createProtectingReport(
+                "페르시안", "고양이", ReportTag.PROTECTING, LocalDate.now().minusDays(1),
+                "서울시 마포구 월드컵북로 212", testUser, Sex.F, "2살", "4kg", "흰색", Neutering.Y,
+                "왼쪽 귀에 상처", "마포대교 근처", "NOTICE-2024-001",
+                LocalDate.now(), LocalDate.now().plusDays(14), "마포구 동물보호센터", "02-123-4567", "마포구청",
+                new BigDecimal("37.483569"), new BigDecimal("127.032675")
+        );
+
+        reportRepository.save(missingReport);
+        reportRepository.save(witnessReport);
+        reportRepository.save(protectingReport);
+    }
+}

--- a/src/test/java/com/kuit/findyou/domain/report/service/detail/ReportDetailServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/detail/ReportDetailServiceImplTest.java
@@ -62,7 +62,7 @@ class ReportDetailServiceImplTest {
 
         when(dummyReport.getId()).thenReturn(reportId);
         when(protectingStrategy.getReport(reportId)).thenReturn(dummyReport);
-        when(interestReportRepository.existsByReport_IdAndUser_Id(reportId, userId)).thenReturn(true);
+        when(interestReportRepository.existsByReportIdAndUserId(reportId, userId)).thenReturn(true);
         when(protectingStrategy.getDetail(dummyReport, true)).thenReturn(dummyDto);
 
         // when
@@ -73,7 +73,7 @@ class ReportDetailServiceImplTest {
         assertThat(result).isEqualTo(dummyDto);
 
         verify(protectingStrategy).getReport(reportId);
-        verify(interestReportRepository).existsByReport_IdAndUser_Id(reportId, userId);
+        verify(interestReportRepository).existsByReportIdAndUserId(reportId, userId);
         verify(protectingStrategy).getDetail(dummyReport, true);
     }
 
@@ -89,7 +89,7 @@ class ReportDetailServiceImplTest {
 
         when(dummyReport.getId()).thenReturn(reportId);
         when(missingStrategy.getReport(reportId)).thenReturn(dummyReport);
-        when(interestReportRepository.existsByReport_IdAndUser_Id(reportId, userId)).thenReturn(false);
+        when(interestReportRepository.existsByReportIdAndUserId(reportId, userId)).thenReturn(false);
         when(missingStrategy.getDetail(dummyReport, false)).thenReturn(dummyDto);
 
         // when
@@ -100,7 +100,7 @@ class ReportDetailServiceImplTest {
         assertThat(result).isEqualTo(dummyDto);
 
         verify(missingStrategy).getReport(reportId);
-        verify(interestReportRepository).existsByReport_IdAndUser_Id(reportId, userId);
+        verify(interestReportRepository).existsByReportIdAndUserId(reportId, userId);
         verify(missingStrategy).getDetail(dummyReport, false);
     }
 
@@ -116,7 +116,7 @@ class ReportDetailServiceImplTest {
 
         when(dummyReport.getId()).thenReturn(reportId);
         when(witnessStrategy.getReport(reportId)).thenReturn(dummyReport);
-        when(interestReportRepository.existsByReport_IdAndUser_Id(reportId, userId)).thenReturn(true);
+        when(interestReportRepository.existsByReportIdAndUserId(reportId, userId)).thenReturn(true);
         when(witnessStrategy.getDetail(dummyReport, true)).thenReturn(dummyDto);
 
         // when
@@ -127,7 +127,7 @@ class ReportDetailServiceImplTest {
         assertThat(result).isEqualTo(dummyDto);
 
         verify(witnessStrategy).getReport(reportId);
-        verify(interestReportRepository).existsByReport_IdAndUser_Id(reportId, userId);
+        verify(interestReportRepository).existsByReportIdAndUserId(reportId, userId);
         verify(witnessStrategy).getDetail(dummyReport, true);
     }
 

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ReportRetrieveServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ReportRetrieveServiceImplTest.java
@@ -1,0 +1,113 @@
+package com.kuit.findyou.domain.report.service.retrieve;
+
+import com.kuit.findyou.domain.report.dto.request.ReportViewType;
+import com.kuit.findyou.domain.report.dto.response.Card;
+import com.kuit.findyou.domain.report.dto.response.CardResponseDTO;
+import com.kuit.findyou.domain.report.dto.response.ReportProjection;
+import com.kuit.findyou.domain.report.model.Report;
+import com.kuit.findyou.domain.report.model.ReportTag;
+import com.kuit.findyou.domain.report.repository.InterestReportRepository;
+import com.kuit.findyou.domain.report.repository.ReportRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Transactional
+@ActiveProfiles("test")
+class ReportRetrieveServiceImplTest {
+
+    @Mock
+    private InterestReportRepository interestReportRepository;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    private ReportRetrieveServiceImpl reportRetrieveService;
+
+    @BeforeEach
+    void setUp() {
+        reportRetrieveService = new ReportRetrieveServiceImpl(interestReportRepository, reportRepository);
+    }
+
+    @Test
+    @DisplayName("필터 조건에 따라 보고서 리스트를 조회하고 관심 여부를 포함한 결과 반환")
+    void retrieveReportsWithFilters_success() {
+        // given
+        Long userId = 1L;
+        Long reportId = 100L;
+
+        ReportProjection projection = mock(ReportProjection.class);
+        when(projection.getReportId()).thenReturn(reportId);
+        when(projection.getThumbnailImageUrl()).thenReturn("http://example.com/image.jpg");
+        when(projection.getTitle()).thenReturn("골든 리트리버");
+        when(projection.getTag()).thenReturn("MISSING");
+        when(projection.getDate()).thenReturn(LocalDate.of(2025, 7, 10));
+        when(projection.getAddress()).thenReturn("서울시 강남구");
+
+        List<ReportProjection> projections = List.of(projection);
+        Slice<ReportProjection> reportSlice = new SliceImpl<>(projections, PageRequest.of(0, 20), false);
+
+        when(reportRepository.findReportsWithFilters(
+                any(), any(), any(), any(), any(), any(), anyLong(), any()
+        )).thenReturn(reportSlice);
+
+        when(interestReportRepository.findInterestedReportIdsByUserIdAndReportIds(eq(userId), eq(List.of(reportId))))
+                .thenReturn(List.of(reportId));
+
+        // when
+        CardResponseDTO result = reportRetrieveService.retrieveReportsWithFilters(
+                ReportViewType.REPORTING,
+                null, null,
+                null, null, null,
+                Long.MAX_VALUE,
+                userId
+        );
+
+        // then
+        assertThat(result.cards()).hasSize(1);
+        Card card = result.cards().get(0);
+
+        assertThat(card.reportId()).isEqualTo(reportId);
+        assertThat(card.thumbnailImageUrl()).isEqualTo("http://example.com/image.jpg");
+        assertThat(card.title()).isEqualTo("골든 리트리버");
+        assertThat(card.tag()).isEqualTo(ReportTag.MISSING.getValue());
+        assertThat(card.location()).isEqualTo("서울시 강남구");
+        assertThat(card.interest()).isTrue();
+
+        assertThat(result.lastReportId()).isEqualTo(reportId);
+        assertThat(result.isLast()).isTrue();
+
+        // verify
+        verify(reportRepository).findReportsWithFilters(
+                eq(List.of(ReportTag.MISSING, ReportTag.WITNESS)),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                eq(Long.MAX_VALUE),
+                eq(PageRequest.of(0, 20))
+        );
+
+        verify(interestReportRepository).findInterestedReportIdsByUserIdAndReportIds(
+                eq(userId),
+                eq(List.of(reportId))
+        );
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #19 

## Work Description 📝
- 글 조회 API 에 대한 테스트 코드를 작성하였습니다.

### 레포지토리 레이어 테스트
글 조회 API 에 활용되는 레포지토리 단 메서드들을 검증하였습니다.
기존과 마찬가지로 @DataJpaTest 를 활용하였습니다.

### 서비스 레이어 테스트
레포지토리 레이어에서 이미 메서드들을 검증하였기 때문에, 레포지토리 레이어 메서드들을 모두 Mock 처리해두고 로직을 테스트하였습니다.

### 컨트롤러 통합 테스트
글 조회 API 를 통합테스트하였습니다.
별도의 Mock 처리를 하지 않고 RestAssured 를 활용해서 통합 테스트를 진행하였습니다.

### 쿼리 최적화
interestReportRepository 는 저희 프로젝트 구조상 Report, User 와 연결된 관계(중간) 테이블 입니다. 여기서 특정 유저가 특정 글에 관심을 갖는지 여부를 판단하기 위해 기존에 Spring Data JPA 가 자동으로 생성해주는 `boolean existsByReport_IdAndUser_Id(Long reportId, Long userId);` 메서드를 활용하였었는데, 이 쿼리를 활용할 경우 
관계테이블만을 확인해서 exist 여부를 판단하는 것이 아니라, Report, User 각각의 테이블에 대해 left join 이 발생하는 것을 확인하였습니다. 
이 left join 은 불필요한 로직이라고 판단이 들어서 native query 를 활용해 오직 InterestReport 테이블만을 확인해 exist 여부를 확인할 수 있도록 구현을 변경하였습니다.
<img width="540" height="185" alt="스크린샷 2025-07-17 오후 4 48 28" src="https://github.com/user-attachments/assets/41ccf397-f9bf-4d7d-abf5-b2ae3750cb6d" />


- **기존 쿼리**
<img width="365" height="446" alt="스크린샷 2025-07-17 오후 4 51 27" src="https://github.com/user-attachments/assets/c6ed20ec-ff97-4db6-b434-f248dfac3832" />

- **변경 후 쿼리**
<img width="254" height="218" alt="스크린샷 2025-07-17 오후 4 50 13" src="https://github.com/user-attachments/assets/72e1beb7-7dc2-4ecc-8e19-2f00e31aaecd" />

## Screenshot 📸
<img width="1212" height="493" alt="스크린샷 2025-07-17 오후 4 48 54" src="https://github.com/user-attachments/assets/33c869bb-1f80-4c6d-9dca-6f3ef4f7828c" />

## Uncompleted Tasks 😅
- 없습니다.

## To Reviewers 📢
