### PR TITLE
[Feat] 게스트 로그인 기능 구현

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.GUEST_LOGIN;
 import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.KAKAO_LOGIN;
 
 @Tag(name = "Login", description = "로그인 관련 API")
@@ -37,7 +38,13 @@ public class AuthController {
         return BaseResponse.ok(authService.kakaoLogin(request));
     }
 
+    // todo 스웨거 명세
+    @Operation(
+            summary = "게스트 로그인 API",
+            description = "디바이스id 식별자를 이용해서 유저 정보와 엑세스 토큰을 얻을 수 있습니다. 기존 게스트가 아니면 별도의 가입 API 호출 없이 정보가 자동으로 저장됩니다."
+    )
     @PostMapping("/login/guest")
+    @CustomExceptionDescription(GUEST_LOGIN)
     public BaseResponse<GuestLoginResponse> guestLogin(@RequestBody GuestLoginRequest request){
         log.info("[guestLogin] deviceId = {}", request.deviceId());
         return BaseResponse.ok(authService.guestLogin(request));

--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -38,7 +38,6 @@ public class AuthController {
         return BaseResponse.ok(authService.kakaoLogin(request));
     }
 
-    // todo 스웨거 명세
     @Operation(
             summary = "게스트 로그인 API",
             description = "디바이스id 식별자를 이용해서 유저 정보와 엑세스 토큰을 얻을 수 있습니다. 기존 게스트가 아니면 별도의 가입 API 호출 없이 정보가 자동으로 저장됩니다."

--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.kuit.findyou.domain.auth.controller;
 
+import com.kuit.findyou.domain.auth.dto.GuestLoginRequest;
+import com.kuit.findyou.domain.auth.dto.GuestLoginResponse;
 import com.kuit.findyou.domain.auth.dto.KakaoLoginRequest;
 import com.kuit.findyou.domain.auth.dto.KakaoLoginResponse;
 import com.kuit.findyou.domain.auth.service.AuthService;
@@ -33,5 +35,11 @@ public class AuthController {
     public BaseResponse<KakaoLoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request){
         log.info("[kakaoLogin]");
         return BaseResponse.ok(authService.kakaoLogin(request));
+    }
+
+    @PostMapping("/login/guest")
+    public BaseResponse<GuestLoginResponse> guestLogin(@RequestBody GuestLoginRequest request){
+        log.info("[guestLogin] deviceId = {}", request.deviceId());
+        return BaseResponse.ok(authService.guestLogin(request));
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/GuestLoginRequest.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/GuestLoginRequest.java
@@ -1,6 +1,10 @@
 package com.kuit.findyou.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "게스트 로그인 요청 DTO")
 public record GuestLoginRequest(
+        @Schema(description = "디바이스 id", example = "asdf1234asdf")
         String deviceId
 ) {
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/GuestLoginRequest.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/GuestLoginRequest.java
@@ -1,0 +1,6 @@
+package com.kuit.findyou.domain.auth.dto;
+
+public record GuestLoginRequest(
+        String deviceId
+) {
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/GuestLoginResponse.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/GuestLoginResponse.java
@@ -1,7 +1,12 @@
 package com.kuit.findyou.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "게스트 로그인 응답 DTO")
 public record GuestLoginResponse (
+        @Schema(description = "유저 식별자")
         Long userId,
+        @Schema(description = "엑세스 토큰")
         String accessToken
 ){
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/GuestLoginResponse.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/GuestLoginResponse.java
@@ -1,0 +1,7 @@
+package com.kuit.findyou.domain.auth.dto;
+
+public record GuestLoginResponse (
+        Long userId,
+        String accessToken
+){
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/AuthService.java
@@ -1,8 +1,12 @@
 package com.kuit.findyou.domain.auth.service;
 
+import com.kuit.findyou.domain.auth.dto.GuestLoginRequest;
+import com.kuit.findyou.domain.auth.dto.GuestLoginResponse;
 import com.kuit.findyou.domain.auth.dto.KakaoLoginRequest;
 import com.kuit.findyou.domain.auth.dto.KakaoLoginResponse;
 
 public interface AuthService {
     KakaoLoginResponse kakaoLogin(KakaoLoginRequest request);
+
+    GuestLoginResponse guestLogin(GuestLoginRequest request);
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/AuthServiceImpl.java
@@ -10,6 +10,7 @@ import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
 import com.kuit.findyou.global.common.exception.CustomException;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,7 +38,7 @@ public class AuthServiceImpl implements AuthService {
                 });
     }
 
-    // todo transactional
+    @Transactional
     @Override
     public GuestLoginResponse guestLogin(GuestLoginRequest request) {
         log.info("[guestLogin] deviceId = {}", request.deviceId());

--- a/src/main/java/com/kuit/findyou/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/AuthServiceImpl.java
@@ -37,6 +37,7 @@ public class AuthServiceImpl implements AuthService {
                 });
     }
 
+    // todo transactional
     @Override
     public GuestLoginResponse guestLogin(GuestLoginRequest request) {
         log.info("[guestLogin] deviceId = {}", request.deviceId());

--- a/src/main/java/com/kuit/findyou/domain/user/model/User.java
+++ b/src/main/java/com/kuit/findyou/domain/user/model/User.java
@@ -53,7 +53,7 @@ public class User extends BaseEntity {
     @Column(columnDefinition = "CHAR(1)", nullable = false, length = 1)
     private ReceiveNotification  receiveNotification = ReceiveNotification.N;
 
-    @Column(length = 100)
+    @Column(length = 100, unique = true)
     private String deviceId;
 
     // 신고글에 대해 orphanRemoval = true 만 설정

--- a/src/main/java/com/kuit/findyou/domain/user/model/User.java
+++ b/src/main/java/com/kuit/findyou/domain/user/model/User.java
@@ -114,4 +114,8 @@ public class User extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
         this.role = Role.USER;
     }
+
+    public boolean isGuest(){
+        return this.role == Role.GUEST;
+    }
 }

--- a/src/main/java/com/kuit/findyou/global/common/response/BaseErrorResponse.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/BaseErrorResponse.java
@@ -1,5 +1,7 @@
 package com.kuit.findyou.global.common.response;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.kuit.findyou.global.common.response.status.ResponseStatus;
 import lombok.Getter;
@@ -13,6 +15,19 @@ public class BaseErrorResponse implements ResponseStatus {
     private final int code;
     private final String message;
     private final LocalDateTime timestamp;
+
+    @JsonCreator
+    public BaseErrorResponse(
+            @JsonProperty("success") boolean success,
+            @JsonProperty("code") int code,
+            @JsonProperty("message") String message,
+            @JsonProperty("timestamp") LocalDateTime timestamp
+    ) {
+        this.success = success;
+        this.code = code;
+        this.message = message;
+        this.timestamp = timestamp;
+    }
 
     public BaseErrorResponse(ResponseStatus status) {
         this.success = false;

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -23,6 +23,9 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     EXPIRED_JWT(401, "만료된 토큰입니다"),
     JWT_NOT_FOUND(400, "토큰을 찾을 수 없습니다"),
 
+    // 로그인
+    GUEST_LOGIN_FAILED(404, "일치하는 게스트가 없습니다."),
+
     // 회원가입
     ALREADY_REGISTERED_USER(400, "이미 회원가입한 유저입니다."),
 

--- a/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
@@ -17,6 +17,10 @@ public enum SwaggerResponseDescription {
 
     CHECK_DUPLICATE_NICKNAME(new LinkedHashSet<>(Set.of())),
 
+    GUEST_LOGIN(new LinkedHashSet<>(Set.of(
+            GUEST_LOGIN_FAILED
+    ))),
+
     KAKAO_LOGIN(new LinkedHashSet<>(Set.of())),
 
     TEST(new LinkedHashSet<>(Set.of(

--- a/src/test/java/com/kuit/findyou/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/service/AuthServiceTest.java
@@ -1,11 +1,15 @@
 package com.kuit.findyou.domain.auth.service;
 
+import com.kuit.findyou.domain.auth.dto.GuestLoginRequest;
+import com.kuit.findyou.domain.auth.dto.GuestLoginResponse;
 import com.kuit.findyou.domain.auth.dto.KakaoLoginRequest;
 import com.kuit.findyou.domain.auth.dto.KakaoLoginResponse;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
+import com.kuit.findyou.global.common.exception.CustomException;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,9 +18,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.GUEST_LOGIN_FAILED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -72,5 +79,64 @@ class AuthServiceTest {
                 .build();
 
         return build;
+    }
+
+    @DisplayName("게스트가 로그인하면 새로 유저를 추가하지 않는다")
+    @Test()
+    void should_DoesNotSaveNewGuest_When_UserWithDeviceIdExists(){
+        // given
+        final String deviceId = "asdf-1234-asdf";
+        final String accessToken = "accessToken";
+
+        User user = mockUser("게스트", Role.GUEST, null);
+        when(userRepository.findByDeviceId(eq(deviceId))).thenReturn(Optional.of(user));
+        when(jwtUtil.createAccessJwt(user.getId(), user.getRole())).thenReturn(accessToken);
+
+        // when
+        GuestLoginResponse response = authService.guestLogin(new GuestLoginRequest(deviceId));
+
+        // then
+        verify(userRepository, never()).save(any());
+        assertThat(response.userId()).isEqualTo(user.getId());
+        assertThat(response.accessToken()).isEqualTo(accessToken);
+    }
+
+    @DisplayName("디바이스 id가 일치하는 유저가 없으면 새로 게스트를 저장한다")
+    @Test()
+    void should_SaveNewGuest_When_UserWithDeviceIdDoesNotExists(){
+        // given
+        final String deviceId = "asdf-1234-asdf";
+        final String accessToken = "accessToken";
+
+        User user = mockUser("게스트", Role.GUEST, null);
+        when(userRepository.findByDeviceId(eq(deviceId))).thenReturn(Optional.empty());
+        when(userRepository.save(any())).thenReturn(user);
+        when(jwtUtil.createAccessJwt(user.getId(), user.getRole())).thenReturn(accessToken);
+
+        // when
+        GuestLoginResponse response = authService.guestLogin(new GuestLoginRequest(deviceId));
+
+        // then
+        verify(userRepository).save(any(User.class));
+        assertThat(response.userId()).isEqualTo(user.getId());
+        assertThat(response.accessToken()).isEqualTo(accessToken);
+    }
+
+    @DisplayName("게스트가 아니면 예외가 발생한다.")
+    @Test()
+    void should_ThrowException_When_NonGuestUserLogsIn(){
+        // given
+        final String deviceId = "asdf-1234-asdf";
+        final String accessToken = "accessToken";
+
+        User user = mockUser("게스트", Role.USER, null);
+        when(userRepository.findByDeviceId(eq(deviceId))).thenReturn(Optional.of(user));
+
+        // when
+        // then
+        assertThatThrownBy(() -> authService.guestLogin(new GuestLoginRequest(deviceId)))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(GUEST_LOGIN_FAILED.getMessage());
+        verify(userRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #42

## Work Description 📝
- 게스트(비회원) 로그인 기능을 구현했습니다.
- 디바이스 id를 요청으로 보냅니다.
- 디바이스 id에 해당하는 유저가 없으면 게스트 등록도 자동으로 수행합니다.
- 만약 디바이스 id에 해당하는 유저가 회원이면, 즉 Role이 USER이면 예외를 일으킵니다.

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
-  없습니다

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 게스트 로그인을 위한 API 엔드포인트가 추가되었습니다. 기기 ID를 통해 게스트 사용자로 로그인할 수 있으며, 성공 시 사용자 ID와 액세스 토큰이 반환됩니다.
  * 사용자 정보에 기기 ID의 고유 제약 조건이 추가되었습니다.

* **버그 수정**
  * 게스트 로그인 실패 시 적절한 오류 메시지와 상태 코드(404)가 반환되도록 개선되었습니다.

* **테스트**
  * 게스트 로그인 성공 및 실패 케이스에 대한 단위 및 통합 테스트가 추가되었습니다.

* **문서화**
  * 오류 응답의 JSON 역직렬화를 지원하는 생성자가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->