### PR TITLE
[Infra] CI 시 테스트 결과 코멘트 추가 구현

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -28,7 +28,7 @@ jobs:
         run: ./gradlew clean build --stacktrace
 
       - name: ✉️ Post test results as a comment on the PR
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: '**/build/test-results/test/TEST-*.xml'

--- a/src/test/java/com/kuit/findyou/domain/breed/service/breedQuery/BreedQueryServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/breed/service/breedQuery/BreedQueryServiceImplTest.java
@@ -46,7 +46,7 @@ class BreedQueryServiceImplTest {
 
         // then
         assertThat(response.dogBreedList()).containsExactlyInAnyOrder("진돗개", "포메라니안");
-        assertThat(response.catBreedList()).containsExactly("코리안 롱헤어");
+        assertThat(response.catBreedList()).containsExactly("코리안 숏헤어");
         assertThat(response.etcBreedList()).containsExactly("기타축종");
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #48 

## Work Description 📝

### ci-workflow.yml 파일 수정
PR 이 올라갈 때에만 CI 가 실행되도록 변경하였습니다.
추후에 CD 는 push 될 때에만 실행되도록 변경할 예정입니다.

### CI 업그레이드
- 테스트 결과를 PR에 코멘트로 등록할 수 있도록 하였습니다.

<img width="939" height="291" alt="스크린샷 2025-08-06 오후 6 54 34" src="https://github.com/user-attachments/assets/47ba2387-7d2a-4650-8a5b-db48660ac2f6" />

- 테스트 실패 시, 실패한 코드 라인에 Check 코멘트를 등록할 수 있도록 하였습니다.

<img width="1363" height="658" alt="스크린샷 2025-08-06 오후 6 49 47" src="https://github.com/user-attachments/assets/680994a2-4589-478b-bfd8-64d854769842" />
이렇게 테스트가 실패할 경우 어디서 테스트가 실패했는지를 알려주도록 설정하였습니다.

## Screenshot 📸
<img width="185" height="115" alt="스크린샷 2025-08-06 오후 6 35 39" src="https://github.com/user-attachments/assets/bc919d16-872c-48f0-9b50-e15cffc2a3ac" />
<img width="491" height="285" alt="스크린샷 2025-08-06 오후 6 37 12" src="https://github.com/user-attachments/assets/4856d4ec-0734-4f8a-80e1-1734937d15d7" />


## Uncompleted Tasks 😅

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 풀 리퀘스트에 대한 테스트 결과를 자동으로 댓글로 게시하고, 실패한 테스트 케이스를 변경된 코드 라인에 주석으로 표시하는 기능이 추가되었습니다.

* **작업(Chores)**
  * 워크플로우가 push 이벤트에서 풀 리퀘스트 대상으로 변경되었습니다.
  * 워크플로우 권한이 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->