### PR TITLE
[Infra] Flyway 기반 DB 마이그레이션 환경 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,10 @@ dependencies {
 
 	// Wiremock
 	testImplementation("org.wiremock:wiremock-standalone:3.2.0")
+
+	// Flyway
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-mysql'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kuit/findyou/domain/user/model/User.java
+++ b/src/main/java/com/kuit/findyou/domain/user/model/User.java
@@ -37,8 +37,7 @@ public class User extends BaseEntity {
     @Column(name = "name", length = 50)
     private String name;
 
-    @Lob
-    @Column(name = "profile_image_url")
+    @Column(name = "profile_image_url", length = 500)
     private String profileImageUrl;
 
     @Column(name = "kakao_id")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,8 @@ spring:
         show_sql: true
         highlight_sql: true
         dialect: org.hibernate.dialect.H2Dialect
+  flyway:
+    enabled: false
 ---
 # 개발용 DB
 spring:
@@ -43,13 +45,16 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true
         show_sql: true
         highlight_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
 ---
 # 배포용 DB
 spring:
@@ -63,12 +68,15 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true
         show_sql: true
         highlight_sql: true
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
 ---
 # 개발용 포트
 spring:

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,285 @@
+-- Flyway 초기 스키마 생성
+-- V1__init_schema.sql
+
+-- 1. 사용자 테이블
+CREATE TABLE users (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(50),
+    profile_image_url LONGTEXT,
+    kakao_id BIGINT,
+    role VARCHAR(20) NOT NULL,
+    receive_notification CHAR(1) NOT NULL DEFAULT 'N',
+    device_id VARCHAR(100),
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 2. 시도 테이블
+CREATE TABLE sidos (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(50) NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 3. 시군구 테이블
+CREATE TABLE sigungus (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(50) NOT NULL,
+    sido_id BIGINT NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (sido_id) REFERENCES sidos(id)
+);
+
+-- 4. 품종 테이블
+CREATE TABLE breeds (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    breed_name VARCHAR(100) NOT NULL,
+    species VARCHAR(20) NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 5. 동물보호센터 테이블
+CREATE TABLE animal_centers (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    jurisdiction VARCHAR(100) NOT NULL,
+    center_name VARCHAR(70) NOT NULL,
+    phone_number VARCHAR(20) NOT NULL,
+    address VARCHAR(255) NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 6. 동물보호과 테이블
+CREATE TABLE animal_departments (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    organization VARCHAR(100) NOT NULL,
+    department VARCHAR(70) NOT NULL,
+    phone_number VARCHAR(20) NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 7. 동물보호소 테이블
+CREATE TABLE animal_shelters (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    location VARCHAR(100) NOT NULL,
+    shelter_name VARCHAR(70) NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 8. 봉사활동 테이블
+CREATE TABLE volunteer_works (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    recruitment_start_at DATE,
+    recruitment_end_at DATE,
+    place VARCHAR(255),
+    volunteer_start_at DATE,
+    volunteer_end_at DATE,
+    volunteer_time VARCHAR(50),
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 9. 신고글 기본 테이블 (상속 구조)
+CREATE TABLE reports (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    breed VARCHAR(20) NOT NULL,
+    species VARCHAR(100) NOT NULL,
+    tag VARCHAR(20) NOT NULL,
+    date DATE NOT NULL,
+    address VARCHAR(200) NOT NULL,
+    latitude DECIMAL(9,6),
+    longitude DECIMAL(9,6),
+    user_id BIGINT,
+    dtype VARCHAR(31) NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- 10. 실종신고 테이블
+CREATE TABLE missing_reports (
+    id BIGINT PRIMARY KEY,
+    sex VARCHAR(10) NOT NULL,
+    rfid VARCHAR(30),
+    age VARCHAR(10) NOT NULL,
+    weight VARCHAR(20) NOT NULL,
+    fur_color VARCHAR(50) NOT NULL,
+    significant TEXT NOT NULL,
+    reporter_name VARCHAR(20),
+    reporter_tel VARCHAR(20),
+    landmark TEXT NOT NULL,
+    FOREIGN KEY (id) REFERENCES reports(id)
+);
+
+-- 11. 보호신고 테이블
+CREATE TABLE protecting_reports (
+    id BIGINT PRIMARY KEY,
+    sex CHAR(1) NOT NULL,
+    age VARCHAR(10) NOT NULL,
+    weight VARCHAR(10) NOT NULL,
+    fur_color VARCHAR(30) NOT NULL,
+    neutering CHAR(1) NOT NULL,
+    significant VARCHAR(200) NOT NULL,
+    found_location VARCHAR(100) NOT NULL,
+    notice_number VARCHAR(30) NOT NULL,
+    notice_start_date DATE NOT NULL,
+    notice_end_date DATE NOT NULL,
+    care_name VARCHAR(50) NOT NULL,
+    care_tel VARCHAR(14) NOT NULL,
+    authority VARCHAR(50) NOT NULL,
+    FOREIGN KEY (id) REFERENCES reports(id)
+);
+
+-- 12. 목격신고 테이블
+CREATE TABLE witness_reports (
+    id BIGINT PRIMARY KEY,
+    fur_color TEXT NOT NULL,
+    significant TEXT NOT NULL,
+    reporter_name VARCHAR(50),
+    landmark VARCHAR(100) NOT NULL,
+    FOREIGN KEY (id) REFERENCES reports(id)
+);
+
+-- 13. 신고글 이미지 테이블
+CREATE TABLE report_images (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    image_url TEXT NOT NULL,
+    uuid VARCHAR(255) NOT NULL,
+    report_id BIGINT,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (report_id) REFERENCES reports(id)
+);
+
+-- 14. 관심글 테이블
+CREATE TABLE interest_reports (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    report_id BIGINT NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (report_id) REFERENCES reports(id)
+);
+
+-- 15. 최근 본 글 테이블
+CREATE TABLE viewed_reports (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    report_id BIGINT NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (report_id) REFERENCES reports(id)
+);
+
+-- 16. 키워드 테이블
+CREATE TABLE keywords (
+    keyword_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(30) NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 17. 구독 테이블
+CREATE TABLE subscribes (
+    subscribe_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    keyword_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (keyword_id) REFERENCES keywords(keyword_id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- 18. FCM 토큰 테이블
+CREATE TABLE fcm_tokens (
+    token_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    fcm_token VARCHAR(100) NOT NULL,
+    user_id BIGINT NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- 19. 알림 내역 테이블
+CREATE TABLE notification_histories (
+    notification_history_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    is_viewed CHAR(1) NOT NULL,
+    user_id BIGINT NOT NULL,
+    report_id BIGINT NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (report_id) REFERENCES reports(id)
+);
+
+-- 20. 추천 뉴스 테이블
+CREATE TABLE recommended_news (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    url VARCHAR(2083) NOT NULL,
+    uploader VARCHAR(255) NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 21. 추천 비디오 테이블
+CREATE TABLE recommended_videos (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    url VARCHAR(255) NOT NULL,
+    uploader VARCHAR(100) NOT NULL,
+    status CHAR(1) NOT NULL DEFAULT 'Y',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 성능 최적화를 위한 추가 인덱스
+-- 카카오 로그인 검색
+CREATE INDEX idx_users_kakao_id ON users(kakao_id);
+
+-- 활성/비활성 유저 필터링
+CREATE INDEX idx_users_status ON users(status);
+
+-- 신고글 태그 필터링
+CREATE INDEX idx_reports_tag ON reports(tag);
+
+-- 시군구 → 시도
+CREATE INDEX idx_sigungus_sido_id ON sigungus(sido_id);
+
+-- 신고글 → 유저
+CREATE INDEX idx_reports_user_id ON reports(user_id);
+
+-- 신고 이미지 → 신고글
+CREATE INDEX idx_report_images_report_id ON report_images(report_id);
+
+-- 관심글
+CREATE INDEX idx_interest_reports_user_id ON interest_reports(user_id);
+CREATE INDEX idx_interest_reports_report_id ON interest_reports(report_id);
+
+-- 최근 본 글
+CREATE INDEX idx_viewed_reports_user_id ON viewed_reports(user_id);
+CREATE INDEX idx_viewed_reports_report_id ON viewed_reports(report_id);

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,285 +1,288 @@
--- Flyway 초기 스키마 생성
 -- V1__init_schema.sql
+-- 초기 데이터베이스 스키마 생성
 
 -- 1. 사용자 테이블
-CREATE TABLE users (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(50),
-    profile_image_url LONGTEXT,
-    kakao_id BIGINT,
-    role VARCHAR(20) NOT NULL,
-    receive_notification CHAR(1) NOT NULL DEFAULT 'N',
-    device_id VARCHAR(100),
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+CREATE TABLE users
+(
+    id                   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name                 VARCHAR(50),
+    profile_image_url    VARCHAR(500),
+    kakao_id             BIGINT,
+    role                 VARCHAR(20) NOT NULL,
+    receive_notification CHAR(1)     NOT NULL DEFAULT 'N',
+    device_id            VARCHAR(100) UNIQUE,
+    status               CHAR(1)     NOT NULL DEFAULT 'Y',
+    created_at           DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at           DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 -- 2. 시도 테이블
-CREATE TABLE sidos (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(50) NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+CREATE TABLE sidos
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name       VARCHAR(50) NOT NULL,
+    status     CHAR(1)     NOT NULL DEFAULT 'Y',
+    created_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 -- 3. 시군구 테이블
-CREATE TABLE sigungus (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(50) NOT NULL,
-    sido_id BIGINT NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    FOREIGN KEY (sido_id) REFERENCES sidos(id)
+CREATE TABLE sigungus
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name       VARCHAR(50) NOT NULL,
+    sido_id    BIGINT      NOT NULL,
+    status     CHAR(1)     NOT NULL DEFAULT 'Y',
+    created_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (sido_id) REFERENCES sidos (id)
 );
 
 -- 4. 품종 테이블
-CREATE TABLE breeds (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+CREATE TABLE breeds
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
     breed_name VARCHAR(100) NOT NULL,
-    species VARCHAR(20) NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    species    VARCHAR(20)  NOT NULL,
+    status     CHAR(1)      NOT NULL DEFAULT 'Y',
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 -- 5. 동물보호센터 테이블
-CREATE TABLE animal_centers (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+CREATE TABLE animal_centers
+(
+    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
     jurisdiction VARCHAR(100) NOT NULL,
-    center_name VARCHAR(70) NOT NULL,
-    phone_number VARCHAR(20) NOT NULL,
-    address VARCHAR(255) NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    center_name  VARCHAR(70)  NOT NULL,
+    phone_number VARCHAR(20)  NOT NULL,
+    address      VARCHAR(255) NOT NULL,
+    status       CHAR(1)      NOT NULL DEFAULT 'Y',
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 -- 6. 동물보호과 테이블
-CREATE TABLE animal_departments (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+CREATE TABLE animal_departments
+(
+    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
     organization VARCHAR(100) NOT NULL,
-    department VARCHAR(70) NOT NULL,
-    phone_number VARCHAR(20) NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    department   VARCHAR(70)  NOT NULL,
+    phone_number VARCHAR(20)  NOT NULL,
+    status       CHAR(1)      NOT NULL DEFAULT 'Y',
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 -- 7. 동물보호소 테이블
-CREATE TABLE animal_shelters (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    location VARCHAR(100) NOT NULL,
-    shelter_name VARCHAR(70) NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+CREATE TABLE animal_shelters
+(
+    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+    address      VARCHAR(100)  NOT NULL,
+    jurisdiction VARCHAR(2000) NOT NULL,
+    phone_number VARCHAR(20)   NOT NULL,
+    shelter_name VARCHAR(70)   NOT NULL,
+    latitude DOUBLE NOT NULL,
+    longitude DOUBLE NOT NULL,
+    status       CHAR(1)       NOT NULL DEFAULT 'Y',
+    created_at   DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 -- 8. 봉사활동 테이블
-CREATE TABLE volunteer_works (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+CREATE TABLE volunteer_works
+(
+    id                   BIGINT AUTO_INCREMENT PRIMARY KEY,
     recruitment_start_at DATE,
-    recruitment_end_at DATE,
-    place VARCHAR(255),
-    volunteer_start_at DATE,
-    volunteer_end_at DATE,
-    volunteer_time VARCHAR(50),
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    recruitment_end_at   DATE,
+    place                VARCHAR(255),
+    volunteer_start_at   DATE,
+    volunteer_end_at     DATE,
+    volunteer_time       VARCHAR(50),
+    status               CHAR(1)  NOT NULL DEFAULT 'Y',
+    created_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 -- 9. 신고글 기본 테이블 (상속 구조)
-CREATE TABLE reports (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    breed VARCHAR(20) NOT NULL,
-    species VARCHAR(100) NOT NULL,
-    tag VARCHAR(20) NOT NULL,
-    date DATE NOT NULL,
-    address VARCHAR(200) NOT NULL,
-    latitude DECIMAL(9,6),
-    longitude DECIMAL(9,6),
-    user_id BIGINT,
-    dtype VARCHAR(31) NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES users(id)
+CREATE TABLE reports
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    breed      VARCHAR(20)  NOT NULL,
+    species    VARCHAR(100) NOT NULL,
+    tag        VARCHAR(20)  NOT NULL,
+    date       DATE         NOT NULL,
+    address    VARCHAR(200) NOT NULL,
+    latitude   DECIMAL(9, 6),
+    longitude  DECIMAL(9, 6),
+    user_id    BIGINT,
+    dtype      VARCHAR(31)  NOT NULL,
+    status     CHAR(1)      NOT NULL DEFAULT 'Y',
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
 -- 10. 실종신고 테이블
-CREATE TABLE missing_reports (
-    id BIGINT PRIMARY KEY,
-    sex VARCHAR(10) NOT NULL,
-    rfid VARCHAR(30),
-    age VARCHAR(10) NOT NULL,
-    weight VARCHAR(20) NOT NULL,
-    fur_color VARCHAR(50) NOT NULL,
-    significant TEXT NOT NULL,
+CREATE TABLE missing_reports
+(
+    id            BIGINT PRIMARY KEY,
+    sex           VARCHAR(10) NOT NULL,
+    rfid          VARCHAR(30),
+    age           VARCHAR(10) NOT NULL,
+    weight        VARCHAR(20) NOT NULL,
+    fur_color     VARCHAR(50) NOT NULL,
+    significant   TEXT        NOT NULL,
     reporter_name VARCHAR(20),
-    reporter_tel VARCHAR(20),
-    landmark TEXT NOT NULL,
-    FOREIGN KEY (id) REFERENCES reports(id)
+    reporter_tel  VARCHAR(20),
+    landmark      TEXT        NOT NULL,
+    FOREIGN KEY (id) REFERENCES reports (id)
 );
 
 -- 11. 보호신고 테이블
-CREATE TABLE protecting_reports (
-    id BIGINT PRIMARY KEY,
-    sex CHAR(1) NOT NULL,
-    age VARCHAR(10) NOT NULL,
-    weight VARCHAR(10) NOT NULL,
-    fur_color VARCHAR(30) NOT NULL,
-    neutering CHAR(1) NOT NULL,
-    significant VARCHAR(200) NOT NULL,
-    found_location VARCHAR(100) NOT NULL,
-    notice_number VARCHAR(30) NOT NULL,
-    notice_start_date DATE NOT NULL,
-    notice_end_date DATE NOT NULL,
-    care_name VARCHAR(50) NOT NULL,
-    care_tel VARCHAR(14) NOT NULL,
-    authority VARCHAR(50) NOT NULL,
-    FOREIGN KEY (id) REFERENCES reports(id)
+CREATE TABLE protecting_reports
+(
+    id                BIGINT PRIMARY KEY,
+    sex               CHAR(1)      NOT NULL,
+    age               VARCHAR(10)  NOT NULL,
+    weight            VARCHAR(10)  NOT NULL,
+    fur_color         VARCHAR(30)  NOT NULL,
+    neutering         CHAR(1)      NOT NULL,
+    significant       VARCHAR(200) NOT NULL,
+    found_location    VARCHAR(100) NOT NULL,
+    notice_number     VARCHAR(30)  NOT NULL,
+    notice_start_date DATE         NOT NULL,
+    notice_end_date   DATE         NOT NULL,
+    care_name         VARCHAR(50)  NOT NULL,
+    care_tel          VARCHAR(14)  NOT NULL,
+    authority         VARCHAR(50)  NOT NULL,
+    FOREIGN KEY (id) REFERENCES reports (id)
 );
 
 -- 12. 목격신고 테이블
-CREATE TABLE witness_reports (
-    id BIGINT PRIMARY KEY,
-    fur_color TEXT NOT NULL,
-    significant TEXT NOT NULL,
+CREATE TABLE witness_reports
+(
+    id            BIGINT PRIMARY KEY,
+    fur_color     TEXT         NOT NULL,
+    significant   TEXT         NOT NULL,
     reporter_name VARCHAR(50),
-    landmark VARCHAR(100) NOT NULL,
-    FOREIGN KEY (id) REFERENCES reports(id)
+    landmark      VARCHAR(100) NOT NULL,
+    FOREIGN KEY (id) REFERENCES reports (id)
 );
 
 -- 13. 신고글 이미지 테이블
-CREATE TABLE report_images (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    image_url TEXT NOT NULL,
-    uuid VARCHAR(255) NOT NULL,
-    report_id BIGINT,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    FOREIGN KEY (report_id) REFERENCES reports(id)
+CREATE TABLE report_images
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    image_url  TEXT         NOT NULL,
+    uuid       VARCHAR(255) NOT NULL,
+    report_id  BIGINT,
+    status     CHAR(1)      NOT NULL DEFAULT 'Y',
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (report_id) REFERENCES reports (id)
 );
 
 -- 14. 관심글 테이블
-CREATE TABLE interest_reports (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    user_id BIGINT NOT NULL,
-    report_id BIGINT NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
+CREATE TABLE interest_reports
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id    BIGINT   NOT NULL,
+    report_id  BIGINT   NOT NULL,
+    status     CHAR(1)  NOT NULL DEFAULT 'Y',
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES users(id),
-    FOREIGN KEY (report_id) REFERENCES reports(id)
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (report_id) REFERENCES reports (id)
 );
 
 -- 15. 최근 본 글 테이블
-CREATE TABLE viewed_reports (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    user_id BIGINT NOT NULL,
-    report_id BIGINT NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
+CREATE TABLE viewed_reports
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id    BIGINT   NOT NULL,
+    report_id  BIGINT   NOT NULL,
+    status     CHAR(1)  NOT NULL DEFAULT 'Y',
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES users(id),
-    FOREIGN KEY (report_id) REFERENCES reports(id)
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (report_id) REFERENCES reports (id)
 );
 
 -- 16. 키워드 테이블
-CREATE TABLE keywords (
+CREATE TABLE keywords
+(
     keyword_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(30) NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    name       VARCHAR(30) NOT NULL,
+    status     CHAR(1)     NOT NULL DEFAULT 'Y',
+    created_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 -- 17. 구독 테이블
-CREATE TABLE subscribes (
+CREATE TABLE subscribes
+(
     subscribe_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    keyword_id BIGINT NOT NULL,
-    user_id BIGINT NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    FOREIGN KEY (keyword_id) REFERENCES keywords(keyword_id),
-    FOREIGN KEY (user_id) REFERENCES users(id)
+    keyword_id   BIGINT   NOT NULL,
+    user_id      BIGINT   NOT NULL,
+    status       CHAR(1)  NOT NULL DEFAULT 'Y',
+    created_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (keyword_id) REFERENCES keywords (keyword_id),
+    FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
 -- 18. FCM 토큰 테이블
-CREATE TABLE fcm_tokens (
-    token_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    fcm_token VARCHAR(100) NOT NULL,
-    user_id BIGINT NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES users(id)
+CREATE TABLE fcm_tokens
+(
+    token_id   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    fcm_token  VARCHAR(100) NOT NULL,
+    user_id    BIGINT       NOT NULL,
+    status     CHAR(1)      NOT NULL DEFAULT 'Y',
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
 -- 19. 알림 내역 테이블
-CREATE TABLE notification_histories (
+CREATE TABLE notification_histories
+(
     notification_history_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    is_viewed CHAR(1) NOT NULL,
-    user_id BIGINT NOT NULL,
-    report_id BIGINT NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES users(id),
-    FOREIGN KEY (report_id) REFERENCES reports(id)
+    is_viewed               CHAR(1)  NOT NULL,
+    user_id                 BIGINT   NOT NULL,
+    report_id               BIGINT   NOT NULL,
+    status                  CHAR(1)  NOT NULL DEFAULT 'Y',
+    created_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (report_id) REFERENCES reports (id)
 );
 
 -- 20. 추천 뉴스 테이블
-CREATE TABLE recommended_news (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    title VARCHAR(255) NOT NULL,
-    url VARCHAR(2083) NOT NULL,
-    uploader VARCHAR(255) NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+CREATE TABLE recommended_news
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title      VARCHAR(255)  NOT NULL,
+    url        VARCHAR(2083) NOT NULL,
+    uploader   VARCHAR(255)  NOT NULL,
+    status     CHAR(1)       NOT NULL DEFAULT 'Y',
+    created_at DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 -- 21. 추천 비디오 테이블
-CREATE TABLE recommended_videos (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    title VARCHAR(255) NOT NULL,
-    url VARCHAR(255) NOT NULL,
-    uploader VARCHAR(100) NOT NULL,
-    status CHAR(1) NOT NULL DEFAULT 'Y',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+CREATE TABLE recommended_videos
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title      VARCHAR(255) NOT NULL,
+    url        VARCHAR(255) NOT NULL,
+    uploader   VARCHAR(100) NOT NULL,
+    status     CHAR(1)      NOT NULL DEFAULT 'Y',
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
--- 성능 최적화를 위한 추가 인덱스
--- 카카오 로그인 검색
-CREATE INDEX idx_users_kakao_id ON users(kakao_id);
-
--- 활성/비활성 유저 필터링
-CREATE INDEX idx_users_status ON users(status);
-
--- 신고글 태그 필터링
-CREATE INDEX idx_reports_tag ON reports(tag);
-
--- 시군구 → 시도
-CREATE INDEX idx_sigungus_sido_id ON sigungus(sido_id);
-
--- 신고글 → 유저
-CREATE INDEX idx_reports_user_id ON reports(user_id);
-
--- 신고 이미지 → 신고글
-CREATE INDEX idx_report_images_report_id ON report_images(report_id);
-
--- 관심글
-CREATE INDEX idx_interest_reports_user_id ON interest_reports(user_id);
-CREATE INDEX idx_interest_reports_report_id ON interest_reports(report_id);
-
--- 최근 본 글
-CREATE INDEX idx_viewed_reports_user_id ON viewed_reports(user_id);
-CREATE INDEX idx_viewed_reports_report_id ON viewed_reports(report_id);
+-- 성능 최적화를 위한 추가 인덱스 (Hibernate가 자동 생성하지 않는 것들)
+CREATE INDEX idx_users_kakao_id ON users (kakao_id);
+CREATE INDEX idx_users_status ON users (status);
+CREATE INDEX idx_reports_tag ON reports (tag);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,6 +13,8 @@ spring:
         show_sql: true
         highlight_sql: true
         dialect: org.hibernate.dialect.H2Dialect
+  flyway:
+    enabled: false
 
 findyou:
   jwt:


### PR DESCRIPTION
## Related issue 🛠
- closed #51 

## Work Description 📝
- Flyway 를 적용하였습니다.

### DB 형상 관리
로컬 환경에서는 얼마든지 ddl-auto 로 편하게 코딩을 해도 되지만, 실제로 운영을 할 때에는 DB의 스키마가 바뀌게되면 기존에 존재하던 데이터에 타격이 간다던지, 에러가 발생하는 상황이 쉽게 발생할 수 있고 그것이 큰 문제로 이어질 수 있다고 합니다.
따라서 Flyway 를 활용하여 DB 형상 관리를 할 수 있도록 하였고, 실제로 sql 스크립트를 활용하여 테이블 구조를 변경하고, ddl-auto: validate 를 통해 실제 JPA 엔티티들과 SQL 문으로 생성된 테이블들 사이에 오차는 없는지 검증할 수 있도록 하였습니다.

### 네이밍 규칙
V{버전}__{이번 버전에 변경된 사항 설명} 
<img width="235" height="142" alt="스크린샷 2025-08-11 오후 3 42 20" src="https://github.com/user-attachments/assets/7371bf44-94ac-4b2e-bfba-853c2926a48e" />

위와 같은 형태로 네이밍을 해야합니다.
버전같은 경우, 1 -> 2 -> 3 -> ... 과 같이 순차적으로 증가되면서 DB의 상태를 확인하고 적용하기 때문에 만약 새로운 변경사항이 생긴다면, 반드시 기존에 존재하던 스크립트들의 버전보다 상위의 버전을 명시해주셔야합니다.
ex) 기존에 V1__init_schema.sql / V2__update_length.sql / V3_update_userId.sql  이런 스크립트들이 존재했고, 새롭게 변경사항이 추가되어야하는 상황이라면 V4__....sql 과 같은 형태로 반드시 더 높은 버전을 명시해주어야합니다. 그러지 않는다면 에러가 터질 수 있습니다.

### 주의 사항
만약 새로운 변경사항이 생겼을 때, 가장 최근에 작성한 스크립트 자체를 변경한다거나 해서는 안됩니다.
반드시 새로운 스크립트를 작성해야하고, 엔티티에 변경된 부분만 스크립트에 작성해주시면 됩니다.

만약 칼럼 하나의 length 만 변경되었다면, 스크립트에도 전체 테이블들을 명시할 필요 없이, ALTER TABLE ... 만 명시해주시면 됩니다.

<img width="1059" height="277" alt="스크린샷 2025-08-11 오후 3 46 04" src="https://github.com/user-attachments/assets/7da56ec0-fdf3-42e3-9501-6b1e19ce47db" />

이렇게 구현해야하는 이유는 위 사진처럼 DB 내에 flyway_schema_history 라는 테이블이 자동으로 생성되게 되는데, 이 테이블이 DB의 버전을 추적하고, 그 버전 이상의 스크립트부터 순차적으로 DB에 적용한다고 합니다. 따라서 이미 적용된 스크립트를 바꿔봐야 아무런 동작이 발생하지 않아서 엔티티는 바뀌었지만 테이블은 그대로라 서로간의 오차가 생겨 에러가 발생할 수 있습니다.

그래서 만약 현재 구조를 가지고 개발 서버에서 서버를 실행하게되면, V1_init_schema.sql 파일이 DB에 반영될 것입니다. 그러다보니 DB에 이미 테이블이 존재했었다면, 새롭게 테이블들을 또 만들려고 시도하게 될 것이라 에러가 발생할 수 있습니다. 그래서 현재 임시로 개발 서버에서 DB 내의 모든 테이블을 지워둔 상태입니다.
이 PR이 머지된 후에는 정상적으로 테이블이 생길 것이고 그 이후로는 별다른 문제가 없을 것으로 판단되니 인지하고계시면 될 것 같습니다.
아마 추후에 운영 서버에서도 테이블을 한 번 초기화하는 작업이 필요할 것 같아요.

## Screenshot 📸
<img width="198" height="431" alt="스크린샷 2025-08-11 오후 3 49 27" src="https://github.com/user-attachments/assets/076d74ac-5a5e-41a2-9c35-1d6860417928" />

flyway 를 통해 로컬에서 테이블들을 생성해본 모습입니다.

## Uncompleted Tasks 😅

## To Reviewers 📢
현재 로컬은 flyway 를 적용하지 않도록 구현해두었습니다.
만약 로컬에서 flyway 가 잘 적용되는지 확인해보고싶으시다면 

  flyway:
    enabled: true
    locations: classpath:db/migration
    
이 코드를 application.yml 파일에 명시하신 후, 로컬 DB 내의 모든 테이블을 삭제한 후에 서버를 재실행하시면 확인할 수 있을겁니다.