### PR TITLE
[Fix] 품종 AI 식별 기능 프롬프트 수정

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/breed/service/breedAiDetection/BreedAiDetectionServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/breed/service/breedAiDetection/BreedAiDetectionServiceImpl.java
@@ -7,8 +7,11 @@ import com.kuit.findyou.domain.breed.util.BreedGroupingUtil;
 import com.kuit.findyou.global.common.exception.CustomException;
 import com.kuit.findyou.global.external.client.OpenAiClient;
 import com.kuit.findyou.global.external.exception.OpenAiClientException;
+import com.kuit.findyou.global.external.exception.OpenAiParsingException;
+import com.kuit.findyou.global.external.util.OpenAiParser;
 import com.kuit.findyou.global.external.util.OpenAiPromptBuilder;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,6 +19,7 @@ import java.util.Map;
 
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.BREED_ANALYSIS_FAILED;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class BreedAiDetectionServiceImpl implements BreedAiDetectionService{
@@ -31,9 +35,15 @@ public class BreedAiDetectionServiceImpl implements BreedAiDetectionService{
             Map<String, List<String>> breedGroup = BreedGroupingUtil.getGroupedBreedNamesBySpecies(breeds);
 
             String prompt = OpenAiPromptBuilder.buildBreedDetectionPrompt(breedGroup);
+            String aiResponse =  openAiClient.analyzeImage(imageUrl, prompt);
 
-            return openAiClient.analyzeImage(imageUrl, prompt);
-        } catch (OpenAiClientException e) {
+            String species = OpenAiParser.parseSpecies(aiResponse);
+            String breed = OpenAiParser.parseBreed(aiResponse, species, breedGroup);
+            List<String> colors = OpenAiParser.parseColors(aiResponse);
+
+            return new BreedAiDetectionResponseDTO(species, breed, colors);
+        } catch (OpenAiClientException | OpenAiParsingException e) {
+            log.warn("품종 판별 실패: {}", e.getMessage());
             throw new CustomException(BREED_ANALYSIS_FAILED);
         }
     }

--- a/src/main/java/com/kuit/findyou/global/external/client/OpenAiClient.java
+++ b/src/main/java/com/kuit/findyou/global/external/client/OpenAiClient.java
@@ -23,7 +23,7 @@ public class OpenAiClient {
         this.openAiRestClient = openAiRestClient;
     }
 
-    public BreedAiDetectionResponseDTO analyzeImage(String imageUrl, String prompt) {
+    public String analyzeImage(String imageUrl, String prompt) {
         try {
             Map<String, Object> requestBody = Map.of(
                     "model", "gpt-4o",
@@ -57,15 +57,7 @@ public class OpenAiClient {
             String content = response.choices().get(0).message().content();
             log.info("OpenAI Vision API 응답: {}", content);
 
-            String species = OpenAiParser.parseSpecies(content);
-            String breed = OpenAiParser.parseBreed(content);
-            List<String> colors = OpenAiParser.parseColors(content);
-
-            return new BreedAiDetectionResponseDTO(species, breed, colors);
-
-        } catch (OpenAiParsingException e) {
-            log.warn("GPT 응답 파싱 실패: {}", e.getMessage());
-            throw new OpenAiClientException("GPT 응답 파싱에 실패하였습니다: " + e.getMessage(), e);
+            return content;
 
         } catch (Exception e) {
             log.error("OpenAI Vision API 호출 중 오류 발생", e);

--- a/src/main/java/com/kuit/findyou/global/external/util/OpenAiParser.java
+++ b/src/main/java/com/kuit/findyou/global/external/util/OpenAiParser.java
@@ -4,6 +4,7 @@ import com.kuit.findyou.global.external.exception.OpenAiParsingException;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class OpenAiParser {
@@ -33,9 +34,29 @@ public class OpenAiParser {
     /**
      * 응답 문자열에서 품종(Breed)을 추출하고 정제
      */
-    public static String parseBreed(String input) {
+    public static String parseBreed(String input, String species, Map<String, List<String>> breedGroup) {
         List<String> parts = parseParts(input);
-        return cleanString(parts.get(1));
+        String breed = cleanString(parts.get(1));
+
+        return validateBreed(breed, species, breedGroup);
+    }
+
+    /**
+     * 품종이 해당 축종의 유효한 품종인지 검증
+     */
+    private static String validateBreed(String breed, String species, Map<String, List<String>> breedGroup) {
+        List<String> validBreeds = breedGroup.get(species);
+
+        if (validBreeds == null || validBreeds.isEmpty()) {
+            throw new OpenAiParsingException("해당 축종에 대한 품종 정보가 없습니다");
+        }
+
+        // 유효하지 않은 품종인 경우
+        if (!validBreeds.contains(breed)) {
+            throw new OpenAiParsingException("유효하지 않은 품종입니다.");
+        }
+
+        return breed;
     }
 
     /**

--- a/src/main/java/com/kuit/findyou/global/external/util/OpenAiParser.java
+++ b/src/main/java/com/kuit/findyou/global/external/util/OpenAiParser.java
@@ -4,70 +4,126 @@ import com.kuit.findyou.global.external.exception.OpenAiParsingException;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public class OpenAiParser {
 
+    // 허용된 축종 목록
+    private static final Set<String> VALID_SPECIES = Set.of("강아지", "고양이", "기타");
+
+    // 허용된 색상 목록
+    private static final Set<String> VALID_COLORS = Set.of(
+            "검은색", "노란색", "점박이", "하얀색", "갈색", "회색", "적색", "기타"
+    );
+
     /**
-     * 응답 문자열에서 축종(Species)을 추출
-     *
-     * @param input GPT 응답 문자열 (예: "개,푸들,하얀색")
-     * @return 축종 문자열 (예: "개")
-     * @throws OpenAiParsingException 포맷이 잘못되었거나 누락 시
+     * 응답 문자열에서 축종(Species)을 추출하고 검증
      */
     public static String parseSpecies(String input) {
         List<String> parts = parseParts(input);
-        return parts.get(0); // 이미 유효성 체크됨
+        String species = cleanString(parts.get(0));
+
+        if (!VALID_SPECIES.contains(species)) {
+            throw new OpenAiParsingException("유효하지 않은 축종입니다.");
+        }
+
+        return species;
     }
 
     /**
-     * 응답 문자열에서 품종(Breed)을 추출
-     *
-     * @param input GPT 응답 문자열 (예: "개,푸들,하얀색")
-     * @return 품종 문자열 (예: "푸들")
-     * @throws OpenAiParsingException 포맷이 잘못되었거나 누락 시
+     * 응답 문자열에서 품종(Breed)을 추출하고 정제
      */
     public static String parseBreed(String input) {
         List<String> parts = parseParts(input);
-        return parts.get(1);
+        return cleanString(parts.get(1));
     }
 
     /**
-     * 응답 문자열에서 색상(Color) 목록을 추출
-     *
-     * @param input GPT 응답 문자열 (예: "개,푸들,하얀색,검은색")
-     * @return 색상 문자열 리스트 (예: ["하얀색", "검은색"])
-     * @throws OpenAiParsingException 포맷이 잘못되었거나 누락 시
+     * 응답 문자열에서 색상(Color) 목록을 추출하고 검증
      */
     public static List<String> parseColors(String input) {
         List<String> parts = parseParts(input);
-        return parts.subList(2, parts.size());
+
+        List<String> validColors = parts.subList(2, parts.size()).stream()
+                .map(OpenAiParser::cleanString)
+                .filter(VALID_COLORS::contains)
+                .distinct()
+                .toList();
+
+        if (validColors.isEmpty()) {
+            throw new OpenAiParsingException("유효한 색상이 없습니다.");
+        }
+
+        return validColors;
     }
 
     /**
-     * 입력 문자열을 쉼표(,) 기준으로 분리하고 유효성 검사를 수행합니다.
-     *
-     * @param input GPT 응답 문자열
-     * @return 축종, 품종, 색상 등을 포함하는 파싱된 리스트
-     * @throws OpenAiParsingException 포맷이 잘못되었거나 항목 수 부족 시
+     * 입력 문자열을 쉼표(,) 기준으로 분리하고 유효성 검사를 수행
      */
     private static List<String> parseParts(String input) {
         if (input == null || input.isBlank()) {
             throw new OpenAiParsingException("입력이 null 이거나 비어 있습니다.");
         }
 
-        if (!input.contains(",")) {
-            throw new OpenAiParsingException("입력에 쉼표(,) 구분자가 없습니다. 잘못된 포맷입니다: " + input);
+        // GPT 응답 정제
+        String cleanedInput = cleanResponse(input);
+
+        if (!cleanedInput.contains(",")) {
+            throw new OpenAiParsingException("입력에 쉼표(,) 구분자가 없습니다. 잘못된 포맷입니다: ");
         }
 
-        List<String> parts = Arrays.stream(input.split(","))
+        List<String> parts = Arrays.stream(cleanedInput.split(","))
                 .map(String::trim)
                 .filter(s -> !s.isBlank())
                 .toList();
 
         if (parts.size() < 3) {
-            throw new OpenAiParsingException("입력 항목이 부족합니다. 최소 3개(축종, 품종, 색상)가 필요합니다. 입력: " + input);
+            throw new OpenAiParsingException("입력 항목이 부족합니다. 최소 3개(축종, 품종, 색상)가 필요합니다.");
         }
 
         return parts;
+    }
+
+    /**
+     * GPT 응답에서 불필요한 문자들을 제거하여 정제
+     */
+    private static String cleanResponse(String input) {
+        if (input == null) {
+            throw new OpenAiParsingException("정제할 입력이 null 입니다.");
+        }
+
+        String result = input
+                .replaceAll("\\\\+n?", "")     // 백슬래시와 \n 제거
+                .replaceAll("\\r?\\n", "")     // 모든 개행문자 제거
+                .replaceAll("\\r", "")         // 캐리지 리턴 제거
+                .replaceAll("^[^가-힣a-zA-Z]*", "") // 앞의 특수문자 제거 (한글/영문이 나올 때까지)
+                .trim();
+
+        if (result.isBlank()) {
+            throw new OpenAiParsingException("정제 후 입력이 비어있습니다. 원본 입력: " + input);
+        }
+
+        return result;
+    }
+
+    /**
+     * 개별 문자열 정제 (축종, 품종, 색상용)
+     */
+    private static String cleanString(String input) {
+        if (input == null) {
+            throw new OpenAiParsingException("정제할 문자열이 null입니다.");
+        }
+
+        String result = input
+                .replaceAll("\\\\+", "")      // 백슬래시 제거
+                .replaceAll("[\\r\\n]", "")   // 개행문자 제거
+                .replaceAll("^\"|\"$", "")    // 앞뒤 따옴표 제거
+                .trim();
+
+        if (result.isBlank()) {
+            throw new OpenAiParsingException("정제 후 문자열이 비어있습니다. 원본 입력: " + input);
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/kuit/findyou/global/external/util/OpenAiPromptBuilder.java
+++ b/src/main/java/com/kuit/findyou/global/external/util/OpenAiPromptBuilder.java
@@ -18,41 +18,25 @@ public class OpenAiPromptBuilder {
         String etcBreeds = String.join(",", groupedBreeds.getOrDefault(Species.ETC.getValue(), List.of()));
 
         return String.format("""
-                        Generate a response in the following format:
-                         \\
+                        Generate a response in the following EXACT format:
                         Species,Breed,Color1,Color2,Color3,...
 
-                         \\
-                        - The species must be one of the following: "강아지", "고양이", "기타".
-                         \\
-                        - The breed must be exactly one, and it must match the species category:
+                        STRICT RULES:
+                        1. The species must be EXACTLY one of: "강아지", "고양이", "기타"
+                        2. The breed must be exactly one from the appropriate category:
+                           - For "강아지": %s
+                           - For "고양이": %s
+                           - For "기타": %s
+                        3. Colors must be one or more from ONLY this list: %s
+                        4. NO extra characters, spaces around commas, newlines, or backslashes
+                        5. Return ONLY the comma-separated format
 
-                         \\
-                        If the species is "강아지":
-                         %s
+                        Valid Examples:
+                        강아지,골든 리트리버,노란색
+                        고양이,러시안 블루,회색,검은색
+                        기타,기타축종,하얀색
 
-                         \\
-                        If the species is "고양이":
-                         %s
-
-                         \\
-                        If the species is "기타":
-                         %s
-
-                         \\
-                        - Colors must be one or more, separated by commas (",").
-                         \\
-                        The color must be chosen from the following fixed list:
-                         %s
-
-                         \\
-                        - There should be no spaces between commas in the color list.
-
-                         \\
-                        **Example input & expected response:**
-                         강아지,골든 리트리버,노란색
-                         고양이,러시안 블루,회색,검은색
-                         기타,기타축종,하얀색""",
+                        IMPORTANT: Your response must start directly with the species name, no other text.""",
                 dogBreeds, catBreeds, etcBreeds, FIXED_COLORS);
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #57 

## Work Description 📝
- 품종 AI 판별하기 기능을 위한 gpt 프롬프트를 수정하고 파싱 로직을 강화하였습니다.

### 프롬프트 수정
기존 프롬프트에 줄 바꿈이 발생하더라도 하나의 문자열로 간주할 수 있도록 \\ 를 넣어주었었는데, 이 백슬래시 때문에 gpt 에서 오는 응답이 정해진 포맷을 벗어나는 경우가 발생했습니다.
<img width="259" height="196" alt="스크린샷 2025-08-13 오전 3 34 54" src="https://github.com/user-attachments/assets/47faeabe-7a7a-4fc8-9001-be2563a0f7cb" />

그래서 이러한 문제를 해결하기 위해 프롬프트 내에서 백슬래시를 모두 제거해주었고, 좀 더 명확하게 gpt 가 이해할 수 있도록 프롬프트를 변경하였습니다.

추가로 파싱 로직을 좀 더 강화하여서, 위와 같이 백슬래시나 개행 문자 같은 것들이 반환되는 경우에도 문제없이 처리할 수 있도록 하였습니다. 
축종 / 품종 / 털 색 모두 잘못된 값인 경우 에러를 반환할 수 있도록 구현하였습니다.

## Screenshot 📸

## Uncompleted Tasks 😅

## To Reviewers 📢
이렇게 변경하고 실험해보니 대략 20회 정도 테스트했을 때 모두 정상적으로 응답하는 모습을 확인할 수 있었습니다!