### PR TITLE
[Refactor] 구조 동물 공공데이터 수집 로직을 서비스 레이어로 분리

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/report/service/sync/ProtectingReportSyncService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/sync/ProtectingReportSyncService.java
@@ -1,0 +1,6 @@
+package com.kuit.findyou.domain.report.service.sync;
+
+public interface ProtectingReportSyncService {
+
+    void syncProtectingReports();
+}

--- a/src/main/java/com/kuit/findyou/domain/report/service/sync/ProtectingReportSyncServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/sync/ProtectingReportSyncServiceImpl.java
@@ -1,0 +1,153 @@
+package com.kuit.findyou.domain.report.service.sync;
+
+import com.kuit.findyou.domain.image.model.ReportImage;
+import com.kuit.findyou.domain.image.repository.ReportImageRepository;
+import com.kuit.findyou.domain.report.model.Neutering;
+import com.kuit.findyou.domain.report.model.ProtectingReport;
+import com.kuit.findyou.domain.report.model.ReportTag;
+import com.kuit.findyou.domain.report.model.Sex;
+import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
+import com.kuit.findyou.global.external.client.KakaoCoordinateClient;
+import com.kuit.findyou.global.external.client.ProtectingAnimalApiClient;
+import com.kuit.findyou.global.external.dto.ProtectingAnimalItemDTO;
+import com.kuit.findyou.global.external.util.ProtectingAnimalParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ProtectingReportSyncServiceImpl implements ProtectingReportSyncService{
+
+    private static final String DEFAULT_SIGNIFICANT = "미등록";
+
+    private final ProtectingReportRepository protectingReportRepository;
+    private final ReportImageRepository reportImageRepository;
+
+    private final ProtectingAnimalApiClient protectingAnimalApiClient;
+    private final KakaoCoordinateClient kakaoCoordinateClient;
+
+    @Transactional
+    @Override
+    public void syncProtectingReports() {
+        long startTime = System.currentTimeMillis();
+
+        try {
+            List<ProtectingAnimalItemDTO> apiItems = protectingAnimalApiClient.fetchAllProtectingAnimals();
+            SyncResult syncResult = synchronizeData(apiItems);
+            logSyncResult(syncResult, startTime);
+        } catch (Exception e) {
+            log.error("[구조동물 데이터 동기화 실패]", e);
+        }
+    }
+
+    private SyncResult synchronizeData(List<ProtectingAnimalItemDTO> apiItems) {
+        Set<String> apiNoticeNumbers = apiItems.stream()
+                .map(ProtectingAnimalItemDTO::noticeNo)
+                .collect(Collectors.toSet());
+
+        List<ProtectingReport> existingReports = protectingReportRepository.findByNoticeNumberIn(apiNoticeNumbers);
+        Set<String> existingNoticeNumbers = existingReports.stream()
+                .map(ProtectingReport::getNoticeNumber)
+                .collect(Collectors.toSet());
+
+        List<ProtectingReport> reportsToDelete = findReportsToDelete(existingReports, apiNoticeNumbers);
+        protectingReportRepository.deleteAll(reportsToDelete);
+
+        List<ReportWithImages> newReportBundles = createNewReports(apiItems, existingNoticeNumbers);
+
+        // 1. report 먼저 저장
+        List<ProtectingReport> newReports = newReportBundles.stream()
+                .map(ReportWithImages::report)
+                .toList();
+        protectingReportRepository.saveAll(newReports);
+
+        // 2. 연관관계 설정 후 이미지 저장
+        List<ReportImage> allImages = new ArrayList<>();
+
+        for (ReportWithImages bundle : newReportBundles) {
+            ProtectingReport report = bundle.report();
+            for (ReportImage image : bundle.images()) {
+                image.setReport(report);
+                allImages.add(image);
+            }
+        }
+        reportImageRepository.saveAll(allImages);
+
+        return new SyncResult(reportsToDelete.size(), newReports.size());
+    }
+
+    private List<ProtectingReport> findReportsToDelete(List<ProtectingReport> existingReports, Set<String> apiNoticeNumbers) {
+        return existingReports.stream()
+                .filter(report -> !apiNoticeNumbers.contains(report.getNoticeNumber()))
+                .toList();
+    }
+
+    private ProtectingReport convertToProtectingReport(ProtectingAnimalItemDTO item) {
+
+        KakaoCoordinateClient.Coordinate coordinate = kakaoCoordinateClient.requestCoordinateOrDefault(item.careAddr());
+
+        return ProtectingReport.builder()
+                .breed(item.kindNm())
+                .species(ProtectingAnimalParser.parseSpecies(item.upKindNm()))
+                .tag(ReportTag.PROTECTING)
+                .date(ProtectingAnimalParser.changeToLocalDate(item.happenDt()))
+                .address(item.careAddr())
+                .latitude(coordinate.latitude())
+                .longitude(coordinate.longitude())
+                .user(null)
+                .sex(Sex.valueOf(item.sexCd()))
+                .age(ProtectingAnimalParser.parseAge(item.age()))
+                .weight(ProtectingAnimalParser.parseWeight(item.weight()))
+                .furColor(ProtectingAnimalParser.parseColor(item.colorCd()))
+                .neutering(Neutering.valueOf(item.neuterYn()))
+                .significant(item.specialMark() != null ? item.specialMark() : DEFAULT_SIGNIFICANT)
+                .foundLocation(item.happenPlace())
+                .noticeNumber(item.noticeNo())
+                .noticeStartDate(ProtectingAnimalParser.changeToLocalDate(item.noticeSdt()))
+                .noticeEndDate(ProtectingAnimalParser.changeToLocalDate(item.noticeEdt()))
+                .careName(item.careNm())
+                .careTel(item.careTel())
+                .authority(item.orgNm())
+                .build();
+    }
+
+    private List<ReportWithImages> createNewReports(List<ProtectingAnimalItemDTO> apiItems, Set<String> existingNoticeNumbers) {
+        return apiItems.stream()
+                .filter(item -> !existingNoticeNumbers.contains(item.noticeNo()))
+                .map(item -> {
+                    ProtectingReport report = convertToProtectingReport(item);
+                    List<ReportImage> images = new ArrayList<>();
+
+                    if (item.popfile1() != null && !item.popfile1().isBlank()) {
+                        images.add(ReportImage.createReportImage(item.popfile1(), UUID.randomUUID().toString()));
+                    }
+                    if (item.popfile2() != null && !item.popfile2().isBlank()) {
+                        images.add(ReportImage.createReportImage(item.popfile2(), UUID.randomUUID().toString()));
+                    }
+
+                    return new ReportWithImages(report, images);
+                })
+                .toList();
+    }
+
+
+    private void logSyncResult(SyncResult result, long startTime) {
+        long duration = System.currentTimeMillis() - startTime;
+        log.info("DB 동기화 완료: 삭제된 데이터 = {}, 추가된 데이터 = {}, 소요 시간 = {}ms",
+                result.deletedCount(), result.addedCount(), duration);
+    }
+
+    // 동기화 결과를 담는 레코드
+    private record SyncResult(int deletedCount, int addedCount) {}
+
+    private record ReportWithImages(ProtectingReport report, List<ReportImage> images) {}
+}

--- a/src/main/java/com/kuit/findyou/global/common/schedule/SchedulerManager.java
+++ b/src/main/java/com/kuit/findyou/global/common/schedule/SchedulerManager.java
@@ -1,5 +1,6 @@
 package com.kuit.findyou.global.common.schedule;
 
+import com.kuit.findyou.domain.report.service.sync.ProtectingReportSyncService;
 import com.kuit.findyou.global.external.client.ProtectingAnimalApiClient;
 import com.kuit.findyou.domain.home.dto.GetHomeResponse;
 import com.kuit.findyou.domain.home.exception.CacheUpdateFailedException;
@@ -19,7 +20,7 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 @RequiredArgsConstructor
 public class SchedulerManager {
 
-    private final ProtectingAnimalApiClient protectingAnimalApiClient;
+    private final ProtectingReportSyncService protectingReportSyncService;
     private final HomeStatisticsService homeStatisticsService;
 
     /**
@@ -27,7 +28,7 @@ public class SchedulerManager {
      */
     @Scheduled(cron = "0 0 4 * * *")
     public void syncProtectingAnimals() {
-        protectingAnimalApiClient.storeProtectingReports();
+        protectingReportSyncService.syncProtectingReports();
     }
 
     /**

--- a/src/main/java/com/kuit/findyou/global/external/client/ProtectingAnimalApiClient.java
+++ b/src/main/java/com/kuit/findyou/global/external/client/ProtectingAnimalApiClient.java
@@ -1,28 +1,17 @@
 package com.kuit.findyou.global.external.client;
 
-import com.kuit.findyou.domain.breed.model.Species;
-import com.kuit.findyou.domain.image.model.ReportImage;
 import com.kuit.findyou.domain.image.repository.ReportImageRepository;
-import com.kuit.findyou.domain.report.model.Neutering;
-import com.kuit.findyou.domain.report.model.ProtectingReport;
-import com.kuit.findyou.domain.report.model.ReportTag;
-import com.kuit.findyou.domain.report.model.Sex;
 import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
 import com.kuit.findyou.global.external.dto.ProtectingAnimalApiFullResponse;
 import com.kuit.findyou.global.external.dto.ProtectingAnimalItemDTO;
 import com.kuit.findyou.global.external.properties.ProtectingAnimalApiProperties;
-import com.kuit.findyou.global.external.util.ProtectingAnimalParser;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClient;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Component
 @Slf4j
@@ -30,79 +19,19 @@ public class ProtectingAnimalApiClient {
 
     private static final int DEFAULT_PAGE_SIZE = 1000;
     private static final String API_ENDPOINT = "/abandonmentPublic_v2";
-    private static final String DEFAULT_SIGNIFICANT = "미등록";
 
-    private final ProtectingReportRepository protectingReportRepository;
-    private final ReportImageRepository reportImageRepository;
     private final ProtectingAnimalApiProperties properties;
     private final RestClient protectingAnimalRestClient;
-    private final KakaoCoordinateClient kakaoCoordinateClient;
 
     public ProtectingAnimalApiClient(
-            ProtectingReportRepository protectingReportRepository,
-            ReportImageRepository reportImageRepository,
             ProtectingAnimalApiProperties properties,
-            KakaoCoordinateClient kakaoCoordinateClient,
             @Qualifier("protectingAnimalRestClient") RestClient protectingAnimalRestClient
     ) {
-        this.protectingReportRepository = protectingReportRepository;
-        this.reportImageRepository = reportImageRepository;
         this.properties = properties;
-        this.kakaoCoordinateClient = kakaoCoordinateClient;
         this.protectingAnimalRestClient = protectingAnimalRestClient;
     }
 
-    @Transactional
-    public void storeProtectingReports() {
-        long startTime = System.currentTimeMillis();
-
-        try {
-            List<ProtectingAnimalItemDTO> apiItems = fetchAllProtectingAnimals();
-            SyncResult syncResult = synchronizeData(apiItems);
-            logSyncResult(syncResult, startTime);
-        } catch (Exception e) {
-            log.error("[구조동물 데이터 동기화 실패]", e);
-        }
-    }
-
-    private SyncResult synchronizeData(List<ProtectingAnimalItemDTO> apiItems) {
-        Set<String> apiNoticeNumbers = apiItems.stream()
-                .map(ProtectingAnimalItemDTO::noticeNo)
-                .collect(Collectors.toSet());
-
-        List<ProtectingReport> existingReports = protectingReportRepository.findByNoticeNumberIn(apiNoticeNumbers);
-        Set<String> existingNoticeNumbers = existingReports.stream()
-                .map(ProtectingReport::getNoticeNumber)
-                .collect(Collectors.toSet());
-
-        List<ProtectingReport> reportsToDelete = findReportsToDelete(existingReports, apiNoticeNumbers);
-        protectingReportRepository.deleteAll(reportsToDelete);
-
-        List<ReportWithImages> newReportBundles = createNewReports(apiItems, existingNoticeNumbers);
-
-        // 1. report 먼저 저장
-        List<ProtectingReport> newReports = newReportBundles.stream()
-                .map(ReportWithImages::report)
-                .toList();
-        protectingReportRepository.saveAll(newReports);
-
-        // 2. 연관관계 설정 후 이미지 저장
-        List<ReportImage> allImages = new ArrayList<>();
-
-        for (ReportWithImages bundle : newReportBundles) {
-            ProtectingReport report = bundle.report();
-            for (ReportImage image : bundle.images()) {
-                image.setReport(report);
-                allImages.add(image);
-            }
-        }
-        reportImageRepository.saveAll(allImages);
-
-        return new SyncResult(reportsToDelete.size(), newReports.size());
-    }
-
-
-    private List<ProtectingAnimalItemDTO> fetchAllProtectingAnimals() {
+    public List<ProtectingAnimalItemDTO> fetchAllProtectingAnimals() {
         List<ProtectingAnimalItemDTO> allItems = new ArrayList<>();
         int pageNo = 1;
 
@@ -139,6 +68,7 @@ public class ProtectingAnimalApiClient {
                 .uri(uriBuilder -> uriBuilder
                         .path(API_ENDPOINT)
                         .queryParam("serviceKey", properties.apiKey())
+                        .queryParam("bgnde", "20250814")
                         .queryParam("pageNo", pageNo)
                         .queryParam("numOfRows", DEFAULT_PAGE_SIZE)
                         .queryParam("_type", "json")
@@ -162,71 +92,5 @@ public class ProtectingAnimalApiClient {
 
         return currentPage >= totalPages;
     }
-
-    private List<ProtectingReport> findReportsToDelete(List<ProtectingReport> existingReports, Set<String> apiNoticeNumbers) {
-        return existingReports.stream()
-                .filter(report -> !apiNoticeNumbers.contains(report.getNoticeNumber()))
-                .toList();
-    }
-
-    private ProtectingReport convertToProtectingReport(ProtectingAnimalItemDTO item) {
-
-        KakaoCoordinateClient.Coordinate coordinate = kakaoCoordinateClient.requestCoordinateOrDefault(item.careAddr());
-
-        return ProtectingReport.builder()
-                .breed(item.kindNm())
-                .species(ProtectingAnimalParser.parseSpecies(item.upKindNm()))
-                .tag(ReportTag.PROTECTING)
-                .date(ProtectingAnimalParser.changeToLocalDate(item.happenDt()))
-                .address(item.careAddr())
-                .latitude(coordinate.latitude())
-                .longitude(coordinate.longitude())
-                .user(null)
-                .sex(Sex.valueOf(item.sexCd()))
-                .age(ProtectingAnimalParser.parseAge(item.age()))
-                .weight(ProtectingAnimalParser.parseWeight(item.weight()))
-                .furColor(ProtectingAnimalParser.parseColor(item.colorCd()))
-                .neutering(Neutering.valueOf(item.neuterYn()))
-                .significant(item.specialMark() != null ? item.specialMark() : DEFAULT_SIGNIFICANT)
-                .foundLocation(item.happenPlace())
-                .noticeNumber(item.noticeNo())
-                .noticeStartDate(ProtectingAnimalParser.changeToLocalDate(item.noticeSdt()))
-                .noticeEndDate(ProtectingAnimalParser.changeToLocalDate(item.noticeEdt()))
-                .careName(item.careNm())
-                .careTel(item.careTel())
-                .authority(item.orgNm())
-                .build();
-    }
-
-    private List<ReportWithImages> createNewReports(List<ProtectingAnimalItemDTO> apiItems, Set<String> existingNoticeNumbers) {
-        return apiItems.stream()
-                .filter(item -> !existingNoticeNumbers.contains(item.noticeNo()))
-                .map(item -> {
-                    ProtectingReport report = convertToProtectingReport(item);
-                    List<ReportImage> images = new ArrayList<>();
-
-                    if (item.popfile1() != null && !item.popfile1().isBlank()) {
-                        images.add(ReportImage.createReportImage(item.popfile1(), UUID.randomUUID().toString()));
-                    }
-                    if (item.popfile2() != null && !item.popfile2().isBlank()) {
-                        images.add(ReportImage.createReportImage(item.popfile2(), UUID.randomUUID().toString()));
-                    }
-
-                    return new ReportWithImages(report, images);
-                })
-                .toList();
-    }
-
-
-    private void logSyncResult(SyncResult result, long startTime) {
-        long duration = System.currentTimeMillis() - startTime;
-        log.info("DB 동기화 완료: 삭제된 데이터 = {}, 추가된 데이터 = {}, 소요 시간 = {}ms",
-                result.deletedCount(), result.addedCount(), duration);
-    }
-
-    // 동기화 결과를 담는 레코드
-    private record SyncResult(int deletedCount, int addedCount) {}
-
-    private record ReportWithImages(ProtectingReport report, List<ReportImage> images) {}
 
 }

--- a/src/main/java/com/kuit/findyou/global/external/client/ProtectingAnimalApiClient.java
+++ b/src/main/java/com/kuit/findyou/global/external/client/ProtectingAnimalApiClient.java
@@ -68,7 +68,6 @@ public class ProtectingAnimalApiClient {
                 .uri(uriBuilder -> uriBuilder
                         .path(API_ENDPOINT)
                         .queryParam("serviceKey", properties.apiKey())
-                        .queryParam("bgnde", "20250814")
                         .queryParam("pageNo", pageNo)
                         .queryParam("numOfRows", DEFAULT_PAGE_SIZE)
                         .queryParam("_type", "json")


### PR DESCRIPTION
## Related issue 🛠
- closed #66 

## Work Description 📝
- 구조 동물 데이터 수집 로직을 서비스 레이어로 분리하였습니다.

기존에는 구조 동물 데이터를 외부에서 받아와 DB에 저장하는 로직이 ProtectingAnimalApiClient 내에 존재했었습니다.
하지만 생각해보니 API 에 요청을 보내는 Client 는 최대한 순수하게 가져가고, 내부 DB에 저장하는 비즈니스 로직은 별도의 서비스로 분리하는 것이 더 낫겠다는 생각이 들었습니다.
그에 따라 ProtectingReportSyncService 라는 서비스 클래스를 만들어서, 구조 동물 데이터를 받아온 후 그 데이터들을 가공하는 책임을 이 서비스 클래스에 위임하도록 하였습니다.

변경 후에도 문제없이 데이터가 저장되는 모습을 볼 수 있었습니다.

## Screenshot 📸

## Uncompleted Tasks 😅
- 없습니다.

## To Reviewers 📢
