### PR TITLE
[Fix] 시도 데이터 불일치 케이스 해결

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/report/service/sync/ProtectingReportSyncServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/sync/ProtectingReportSyncServiceImpl.java
@@ -101,7 +101,7 @@ public class ProtectingReportSyncServiceImpl implements ProtectingReportSyncServ
                 .species(ProtectingAnimalParser.parseSpecies(item.upKindNm()))
                 .tag(ReportTag.PROTECTING)
                 .date(ProtectingAnimalParser.parseDate(item.happenDt()))
-                .address(item.careAddr())
+                .address(ProtectingAnimalParser.parseAddress(item.careAddr()))
                 .latitude(coordinate.latitude())
                 .longitude(coordinate.longitude())
                 .user(null)

--- a/src/main/java/com/kuit/findyou/global/external/util/ProtectingAnimalParser.java
+++ b/src/main/java/com/kuit/findyou/global/external/util/ProtectingAnimalParser.java
@@ -15,6 +15,32 @@ public class ProtectingAnimalParser {
     private static final String UNKNOWN = "미상";
     private static final LocalDate UNKNOWN_DATE = LocalDate.of(2000, 1, 1);
 
+    private static final String JEONBUK_OLD = "전라북도";
+    private static final String JEONBUK_NEW = "전북특별자치도";
+    private static final String GANGWON_OLD = "강원도";
+    private static final String GANGWON_NEW = "강원특별자치도";
+
+    /**
+     * 주소 문자열의 광역자치단체 명칭을 최신 표기로 정규화
+     * 예) 전라북도 김제시 하나아파트 -> 전북특별자치도 김제시 하나아파트 / 강원도 고성군 -> 강원특별자치도 고성군
+     *
+     * null/blank 는 "미상" 반환
+     * 이미 "전북특별자치도" / "강원특별자치도" 인 경우 그대로 유지
+     * 선행 공백 후 시작하는 "전라북도" / "강원도" 도 치환
+     *
+     * @param address 구조동물 공공데이터가 제공하는 주소 정보
+     * @return 파싱된 주소
+     */
+    public static String parseAddress(String address) {
+        if (address == null || address.isBlank()) return UNKNOWN;
+
+        // "전라북도"를 "전북특별자치도"로 치환
+        // "강원도"를 "강원특별자치도"로 치환
+        return address
+                .replace(JEONBUK_OLD, JEONBUK_NEW)
+                .replace(GANGWON_OLD, GANGWON_NEW);
+    }
+
     /**
      * "yyyyMMdd" 형식의 날짜 문자열을 LocalDate 로 변환.
      * 예: "20240718" → LocalDate.of(2024, 7, 18)


### PR DESCRIPTION
## Related issue 🛠
- closed #84 

## Work Description 📝
- 시도 불일치 케이스를 해결하였습니다.

### 시도 불일치 케이스 해결
공공데이터에서 제공하는 시/도 정보에는 전북특별자치도, 강원특별자치도 라는 지명이 존재합니다.
다만 과거에는 전라북도, 강원도 라는 명칭을 활용했기 때문인지, 구조동물 API 에서 제공하는 다수의 데이터가 careAddr 로 전라북도, 강원도 라는 지명을 그대로 활용하고 있는 모습을 확인할 수 있었습니다.

여기서 문제가 발생하게되는데, 저희 프로젝트 로직상 시/도, 시/군/구 로 필터링 로직이 들어갈 때는 DB에 존재하는 시/도, 시/군/구 정보를 바탕으로 필터링이 들어가게됩니다.
이 때 DB에 저장하는 시/도 정보는 공공데이터에서 제공하는 시/도 정보를 그대로 활용하기 때문에 전라북도/강원도가 아닌 전북특별자치도/강원특별자치도 라는 지명이 저장되어있는 상태인데, 그러다보니 만약 보호소주소가 전라북도 ~~~ 와 같이 과거의 지명으로 저장되어있는 경우, 전북특별자치도로 필터링을 걸고 조회를 할 때 정상적으로 조회가 되지 않는 문제가 발생했습니다.

이러한 이슈는 구조동물 공공데이터를 활용할 때에만 발생하였고, 분실동물 공공데이터는 이미 정합성이 맞춰져있는 것인지 이러한 문제가 발생하지 않아서 우선은 구조동물 공공데이터를 동기화할 때 전라북도 -> 전북특별자치도 / 강원도 -> 강원특별자치도 로 변경해서 저장되도록 로직을 추가해주었습니다.

## Screenshot 📸
<img width="1239" height="667" alt="스크린샷 2025-08-27 오후 9 55 12" src="https://github.com/user-attachments/assets/1e94f3c1-9f7a-483c-bfaa-7642be4edd27" />
<img width="826" height="261" alt="스크린샷 2025-08-27 오후 9 55 29" src="https://github.com/user-attachments/assets/e9dd23ef-8218-4b40-b600-3feb53fd5e1f" />

## Uncompleted Tasks 😅
- 없습니다.

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 주소 표기 일관성 개선: ‘전라북도’→‘전북특별자치도’, ‘강원도’→‘강원특별자치도’로 자동 정규화하여 혼재되던 지역명 문제 해소.
  * 비어있거나 알 수 없는 주소는 ‘미상’으로 안전하게 표시합니다.
  * 보호중 신고 정보의 주소 처리를 파서로 통일하여 주소 표기가 일관되며, 지도 좌표 및 기타 정보는 기존과 동일하게 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->