### PR TITLE
[Feat] MDC 로깅 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 ### VS Code ###
 .vscode/
 
+### log ###
+logs/

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -48,6 +48,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    volumes:
+      - ${LOG_DIRECTORY}:/logs
 
 volumes:
   mysql-data:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -11,5 +11,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: prod
       TZ: Asia/Seoul
+    volumes:
+      - ${LOG_DIRECTORY}:/logs
 
 #test

--- a/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
@@ -8,6 +8,7 @@ import org.hibernate.TypeMismatchException;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -21,6 +22,15 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 @Slf4j
 @RestControllerAdvice
 public class GlobalControllerAdvice {
+
+    /**
+     * 잘못된 HTTP 메서드로 요청을 보낼 시 발생 (405 Method Not Allowed)
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public BaseErrorResponse handle_HttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e){
+        log.error("[handle_HttpRequestMethodNotSupportedException]", e);
+        return new BaseErrorResponse(METHOD_NOT_ALLOWED);
+    }
 
     /**
      * 숫자/boolean 등의 타입이 일치하지 않는 경우 발생하는 Hibernate 예외 처리

--- a/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
+++ b/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
@@ -19,8 +19,13 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final MDCLoggingFilter mdcLoggingFilter;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    // MDCLoggingFilter 명시적 빈 등록
+    @Bean
+    public MDCLoggingFilter mdcLoggingFilter() {
+        return new MDCLoggingFilter();
+    }
 
     private final String[] PERMIT_URL = {
             "/api/v2/auth/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
@@ -52,13 +57,13 @@ public class SecurityConfig {
 //                        .requestMatchers(HttpMethod.POST, "/api/v2/users").permitAll()
 //                        .anyRequest().authenticated());
 
-        // MDC 필터 추가
-        http
-                .addFilterBefore(mdcLoggingFilter, UsernamePasswordAuthenticationFilter.class);
-
         // 토큰 검증 필터 추가
         http
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        // MDC 필터 추가 - 반드시 JwtAuthenticationFilter 이전에 실행되도록 설정
+        http
+                .addFilterBefore(mdcLoggingFilter(), JwtAuthenticationFilter.class);
 
         // 토큰 검증 예외 처리 추가
         http

--- a/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
+++ b/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.kuit.findyou.global.config;
 
 import com.kuit.findyou.global.jwt.security.CustomAuthenticationEntryPoint;
 import com.kuit.findyou.global.jwt.filter.JwtAuthenticationFilter;
+import com.kuit.findyou.global.logging.MDCLoggingFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,7 +19,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final MDCLoggingFilter mdcLoggingFilter;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
     private final String[] PERMIT_URL = {
             "/api/v2/auth/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
             "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/swagger-ui/index.html",
@@ -48,6 +51,10 @@ public class SecurityConfig {
 //                        .requestMatchers(PERMIT_URL).permitAll()
 //                        .requestMatchers(HttpMethod.POST, "/api/v2/users").permitAll()
 //                        .anyRequest().authenticated());
+
+        // MDC 필터 추가
+        http
+                .addFilterBefore(mdcLoggingFilter, UsernamePasswordAuthenticationFilter.class);
 
         // 토큰 검증 필터 추가
         http

--- a/src/main/java/com/kuit/findyou/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/filter/JwtAuthenticationFilter.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -36,6 +37,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if(validateIfTokenExists(request, token)){
             // UserDetails 생성
             Long userId = jwtUtil.getUserId(token);
+
+            // jwt 인증 시 user_id 를 MDC에 삽입
+            MDC.put("user_id", String.valueOf(userId));
 
             // userDetails 조회
             UserDetails userDetails = customUserDetailsService.loadUserByUsername(String.valueOf(userId));

--- a/src/main/java/com/kuit/findyou/global/logging/MDCLoggingFilter.java
+++ b/src/main/java/com/kuit/findyou/global/logging/MDCLoggingFilter.java
@@ -1,0 +1,30 @@
+package com.kuit.findyou.global.logging;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class MDCLoggingFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        try {
+            String requestId = ((HttpServletRequest)servletRequest).getHeader("X-Request-ID");
+            MDC.put("request_id", Objects.toString(requestId, UUID.randomUUID().toString()));
+
+            filterChain.doFilter(servletRequest, servletResponse);
+        } finally {
+            MDC.clear(); // 메모리 누수 방지
+        }
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/logging/MDCLoggingFilter.java
+++ b/src/main/java/com/kuit/findyou/global/logging/MDCLoggingFilter.java
@@ -16,8 +16,12 @@ public class MDCLoggingFilter extends OncePerRequestFilter {
                                     jakarta.servlet.http.HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
         try {
-            String requestId = request.getHeader("X-Request-ID");
-            MDC.put("request_id", Objects.toString(requestId, UUID.randomUUID().toString()));
+            String rawRequestId = request.getHeader("X-Request-ID");
+            String requestId = (rawRequestId == null || rawRequestId.trim().isEmpty())
+                    ? UUID.randomUUID().toString()
+                    : rawRequestId;
+
+            MDC.put("request_id", requestId);
             filterChain.doFilter(request, response);
         } finally {
             MDC.clear();

--- a/src/main/java/com/kuit/findyou/global/logging/MDCLoggingFilter.java
+++ b/src/main/java/com/kuit/findyou/global/logging/MDCLoggingFilter.java
@@ -3,28 +3,24 @@ package com.kuit.findyou.global.logging;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.MDC;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Objects;
 import java.util.UUID;
 
-
-@Component
-@Order(Ordered.HIGHEST_PRECEDENCE)
-public class MDCLoggingFilter implements Filter {
+public class MDCLoggingFilter extends OncePerRequestFilter {
 
     @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+    protected void doFilterInternal(HttpServletRequest request,
+                                    jakarta.servlet.http.HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
         try {
-            String requestId = ((HttpServletRequest)servletRequest).getHeader("X-Request-ID");
+            String requestId = request.getHeader("X-Request-ID");
             MDC.put("request_id", Objects.toString(requestId, UUID.randomUUID().toString()));
-
-            filterChain.doFilter(servletRequest, servletResponse);
+            filterChain.doFilter(request, response);
         } finally {
-            MDC.clear(); // 메모리 누수 방지
+            MDC.clear();
         }
     }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- 색상 변환기 등록(콘솔용) -->
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="wEx" converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
+
+    <property name="LOG_PATH" value="logs"/>
+
+    <!-- 콘솔 로그 패턴(컬러) -->
+    <property name="console.format"
+              value="[%clr(%d{yyyy-MM-dd HH:mm:ss}){green}:%clr(%-3relative){faint}] [%clr(%thread){magenta}] %highlight(%-5level) %clr(%logger{35}){cyan} - %clr(%msg){yellow}%n"/>
+
+    <!-- 파일 로그 패턴 (텍스트, key=value 형태) -->
+    <property name="file.format"
+              value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%level] [%thread] [%logger] [request_id:%X{request_id}] [user_id:%X{user_id}] %msg%n"/>
+
+    <!-- 콘솔 로그 Appender(컬러) -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${console.format}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- INFO 로그 파일 (텍스트) -->
+    <appender name="INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/info/info.log</file>
+        <encoder>
+            <pattern>${file.format}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/info/info.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>3</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <!-- WARN 로그 파일 (텍스트) -->
+    <appender name="WARN_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/warn/warn.log</file>
+        <encoder>
+            <pattern>${file.format}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/warn/warn.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>3</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <!-- ERROR 로그 파일 (텍스트) -->
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/error/error.log</file>
+        <encoder>
+            <pattern>${file.format}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/error/error.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>3</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="INFO_FILE" />
+        <appender-ref ref="WARN_FILE" />
+        <appender-ref ref="ERROR_FILE" />
+    </root>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -36,7 +36,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${LOG_PATH}/info/info.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
-            <maxHistory>3</maxHistory>
+            <maxHistory>10</maxHistory>
         </rollingPolicy>
     </appender>
 
@@ -54,7 +54,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${LOG_PATH}/warn/warn.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
-            <maxHistory>3</maxHistory>
+            <maxHistory>10</maxHistory>
         </rollingPolicy>
     </appender>
 
@@ -72,7 +72,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${LOG_PATH}/error/error.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
-            <maxHistory>3</maxHistory>
+            <maxHistory>10</maxHistory>
         </rollingPolicy>
     </appender>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -13,7 +13,7 @@
 
     <!-- 파일 로그 패턴 (텍스트, key=value 형태) -->
     <property name="file.format"
-              value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%level] [%thread] [%logger] [request_id:%X{request_id}] [user_id:%X{user_id}] %msg%n"/>
+              value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%level] [%thread] [%logger] [request_id:%X{request_id}] [user_id:%X{user_id}] %msg%n%wEx"/>
 
     <!-- 콘솔 로그 Appender(컬러) -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
## Related issue 🛠
- closed #95 

## Work Description 📝
- MDC 로깅 구현 및 logback 설정

### MDC 적용
기존 V1 구현할 때처럼 MDC 를 적용하여 멀티 스레드 환경에서 요청을 보낸 사용자 / 요청 자체 를 식별할 수 있도록 하였습니다.
V1 때와 구현 방법에 차이는 없기 때문에 이해하기 쉬우실 것 같습니다.
간단히 요약하자면, 유저가 요청과 함께 전송하는 accessToken 에서 user_id 를 꺼내 로그에 추가하도록 합니다. 이 user_id 를 통해서 현재 요청을 보내고 있는 유저가 누구인지를 식별합니다. 

### logback 설정
이 역시 형식 자체는 기존과 동일합니다.

<img width="424" height="242" alt="스크린샷 2025-09-01 오전 2 18 04" src="https://github.com/user-attachments/assets/fb0939d6-a504-44e2-9d2f-d0dbb0eb0fab" />

프로젝트 폴더 바로 하위에 logs 라는 디렉토리를 만들어두신 후 서버를 실행하면, 자동으로 로그들이 level 별로 별도의 디렉토리 에서 관리됩니다.
error 레벨의 로그는 error 디렉토리 하위의 error.log 파일에, info 레벨의 로그는 info 디렉토리 하위의 info.log 파일에 기록됩니다.
파일의 크기가 10MB 가 넘어가면 새로운 파일이 생성되어 로그가 기록되도록 설정하였으며, 로그 파일 유지 기간은 최대 10일로 잡아두었습니다.


## Screenshot 📸

## Uncompleted Tasks 😅
- 없습니다.

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 지원되지 않는 HTTP 메서드 요청에 대해 일관된 405 응답을 반환하도록 예외 처리를 추가했습니다.
  - 요청 상관 로깅을 도입(요청 ID 및 사용자 ID를 로깅 컨텍스트에 포함)하고 이를 보안 필터 체인에 등록했습니다.
  - 콘솔 및 레벨별(정보/경고/오류) 파일 로깅 구성을 추가해 운영 가시성을 향상시켰습니다.

- **Chores**
  - 개발·운영 환경에서 로그 영속화를 위해 로그 디렉터리 볼륨을 마운트하도록 docker-compose를 업데이트했습니다.
  - 로그 폴더를 버전 관리에서 제외하도록 .gitignore에 규칙을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->