### PR TITLE
[Fix] Swagger 운영 환경에서 HTTPS 스킴 인식 안되는 문제 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,6 +112,8 @@ spring:
       host: ${REDIS_HOST}
       port: 6379
 
+server:
+  forward-headers-strategy: framework
 
 openapi:
   protecting-animal:


### PR DESCRIPTION
## Related issue 🛠
- closed #97 

## Work Description 📝
- Swagger 운영 환경에서 HTTPS 스킴 인식 안되는 문제를 수정하였습니다.
<img width="613" height="172" alt="스크린샷 2025-09-01 오후 12 41 19" src="https://github.com/user-attachments/assets/60eb7026-a08f-4a28-9590-52b5155e7d7c" />

찾아보니 NGINX 프록시에 스키마 관련 헤더 설정을 추가해주고, application.yml 파일에 일부 설정을 추가해주면 정상적으로 https 인식이 가능하다고 합니다.
NGINX 가 설치되어있지 않은 개발 서버의 경우에는 애초에 프록시가 존재하지 않기 때문에 알아서 http 로 간주하므로 상관 없다고 합니다.

## Screenshot 📸

## Uncompleted Tasks 😅
- 없습니다.

## To Reviewers 📢
추후에 운영 서버를 띄운 후에 실제로 적용이 되는지를 확인해보아야할 것 같습니다.
사실 운영 서버로 직접 Swagger 를 통해 요청 보낼 일은 없을거라 상관은 없을 것 같지만, 그래도 모두 문제없이 동작하도록 설정 해주는 것이 좋을 것 같아 작업을 진행하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 리버스 프록시(예: 로드 밸런서) 뒤에서 요청 헤더 전달 처리를 개선하여 실제 클라이언트 IP 인식이 정확해졌습니다.
  - 프록시 환경에서 링크 생성 및 리다이렉트 URL이 올바르게 동작하도록 수정했습니다.
  - 외부 접근 시 잘못된 도메인·프로토콜로 인한 리다이렉트 오류 가능성을 감소시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->