### PR TITLE
[Chore] Jacoco 커버리지 리포트 도입

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -24,8 +24,17 @@ jobs:
       - name: 👏🏻 grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: 🐘 build with Gradle (with test)
-        run: ./gradlew clean build --stacktrace
+      - name: 🐘 Run tests with coverage
+        run: ./gradlew clean test --stacktrace
+
+      - name: 📦 Upload JaCoCo HTML report (artifact)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: jacoco-html
+          path: |
+            **/build/reports/jacoco/test/html/**
+          retention-days: 7
 
       - name: ✉️ Post test results as a comment on the PR
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -39,3 +48,13 @@ jobs:
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
           token: ${{ github.token }}
+
+      - name: 📊 Comment JaCoCo coverage summary on PR
+        uses: madrapps/jacoco-report@v1.7.2
+        if: always()
+        with:
+          paths: |
+            **/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ github.token }}
+          title: '📊 JaCoCo Coverage'
+          update-comment: true

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,11 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.0'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
+}
+
+jacoco {
+	toolVersion = "0.8.12"
 }
 
 group = 'com.kuit'
@@ -98,4 +103,88 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport // 테스트 후 자동으로 커버리지 리포트 생성
 }
+
+// Jacoco 테스트 리포트 설정
+jacocoTestReport {
+	dependsOn test // 테스트가 선행되어야 함
+
+	reports {
+		xml.required = true // CI 에서 파싱하기 위해 필요
+		csv.required = false
+		html.required = true // 개발자가 브라우저에서 보기 위해 필요
+	}
+
+	// 커버리지에서 제외할 클래스들
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: [
+					'**/config/**',          // 설정 클래스 제외
+					'**/dto/**',             // DTO 클래스 제외
+					'**/model/**',           // JPA 엔티티 제외
+					'**/*Application.class', // 메인 애플리케이션 클래스 제외
+					'**/exception/**',       // 예외 클래스 제외
+					'**/common/**',          // 공통 클래스 제외
+					'**/constant/**',        // ENUM 클래스 제외
+					'**/logging/**',         // 로그 관련 클래스 제외
+					'**/notification/**',    // 알림 관련 클래스 제외
+					'**/test/**',            // 테스트용 클래스 제외
+					'**/infrastructure/**'   // S3 관련 클래스 제외
+
+			])
+		}))
+	}
+
+	finalizedBy jacocoTestCoverageVerification  // 리포트 생성 후 커버리지 검증
+}
+
+// 커버리지 검증 규칙
+jacocoTestCoverageVerification {
+	dependsOn jacocoTestReport
+
+	violationRules {
+		rule {
+			// 전체 프로젝트 커버리지 규칙
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.00  // 전체 라인 커버리지
+			}
+		}
+
+		rule {
+			// 브랜치 커버리지 규칙
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.00  // 브랜치 커버리지
+			}
+		}
+
+		rule {
+			// 개별 클래스 커버리지 규칙
+			element = 'CLASS'
+			excludes = [
+					'*.config.*',        	 // 설정 클래스 제외
+					'*.dto.*',           	 // DTO 클래스 제외
+					'*.model.*',         	 // 엔티티 클래스 제외
+					'*Application',      	 // 메인 애플리케이션 클래스 제외
+					'*.exception.*',     	 // 예외 클래스 제외
+					'*.common.*',         	 // 공통 클래스 제외
+					'*.constant.*',      	 // ENUM 클래스 제외
+					'*.logging.*',       	 // 로그 관련 클래스 제외
+					'*.notification.*',  	 // 알림 관련 클래스 제외
+					'*.test.*',         	 // 테스트용 클래스 제외
+					'*.infrastructure.*'   // S3 관련 클래스 제외
+			]
+
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.00  // 개별 클래스
+			}
+		}
+	}
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,7 @@ plugins {
 	id 'jacoco'
 }
 
-jacoco {
-	toolVersion = "0.8.12"
-}
+apply from: "$rootDir/jacoco.gradle"
 
 group = 'com.kuit'
 version = '0.0.1-SNAPSHOT'
@@ -99,92 +97,5 @@ dependencies {
 
 	// Jackson xml parsing
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
-}
-
-tasks.named('test') {
-	useJUnitPlatform()
-	finalizedBy jacocoTestReport // 테스트 후 자동으로 커버리지 리포트 생성
-}
-
-// Jacoco 테스트 리포트 설정
-jacocoTestReport {
-	dependsOn test // 테스트가 선행되어야 함
-
-	reports {
-		xml.required = true // CI 에서 파싱하기 위해 필요
-		csv.required = false
-		html.required = true // 개발자가 브라우저에서 보기 위해 필요
-	}
-
-	// 커버리지에서 제외할 클래스들
-	afterEvaluate {
-		classDirectories.setFrom(files(classDirectories.files.collect {
-			fileTree(dir: it, exclude: [
-					'**/config/**',          // 설정 클래스 제외
-					'**/dto/**',             // DTO 클래스 제외
-					'**/model/**',           // JPA 엔티티 제외
-					'**/*Application.class', // 메인 애플리케이션 클래스 제외
-					'**/exception/**',       // 예외 클래스 제외
-					'**/common/**',          // 공통 클래스 제외
-					'**/constant/**',        // ENUM 클래스 제외
-					'**/logging/**',         // 로그 관련 클래스 제외
-					'**/notification/**',    // 알림 관련 클래스 제외
-					'**/test/**',            // 테스트용 클래스 제외
-					'**/infrastructure/**'   // S3 관련 클래스 제외
-
-			])
-		}))
-	}
-
-	finalizedBy jacocoTestCoverageVerification  // 리포트 생성 후 커버리지 검증
-}
-
-// 커버리지 검증 규칙
-jacocoTestCoverageVerification {
-	dependsOn jacocoTestReport
-
-	violationRules {
-		rule {
-			// 전체 프로젝트 커버리지 규칙
-			limit {
-				counter = 'LINE'
-				value = 'COVEREDRATIO'
-				minimum = 0.00  // 전체 라인 커버리지
-			}
-		}
-
-		rule {
-			// 브랜치 커버리지 규칙
-			limit {
-				counter = 'BRANCH'
-				value = 'COVEREDRATIO'
-				minimum = 0.00  // 브랜치 커버리지
-			}
-		}
-
-		rule {
-			// 개별 클래스 커버리지 규칙
-			element = 'CLASS'
-			excludes = [
-					'*.config.*',        	 // 설정 클래스 제외
-					'*.dto.*',           	 // DTO 클래스 제외
-					'*.model.*',         	 // 엔티티 클래스 제외
-					'*Application',      	 // 메인 애플리케이션 클래스 제외
-					'*.exception.*',     	 // 예외 클래스 제외
-					'*.common.*',         	 // 공통 클래스 제외
-					'*.constant.*',      	 // ENUM 클래스 제외
-					'*.logging.*',       	 // 로그 관련 클래스 제외
-					'*.notification.*',  	 // 알림 관련 클래스 제외
-					'*.test.*',         	 // 테스트용 클래스 제외
-					'*.infrastructure.*'   // S3 관련 클래스 제외
-			]
-
-			limit {
-				counter = 'LINE'
-				value = 'COVEREDRATIO'
-				minimum = 0.00  // 개별 클래스
-			}
-		}
-	}
 }
 

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -1,26 +1,28 @@
 plugins.withId('jacoco') {
 
-    jacoco {
-        toolVersion = "0.8.13"
-    }
+    jacoco { toolVersion = "0.8.13" }
 
-    // 모든 Test 작업 공통 설정
+    // 모든 Test 작업 공통 설정: JUnit5
     tasks.withType(Test).configureEach {
         useJUnitPlatform()
-        finalizedBy("jacocoTestReport") // test 후 리포트
     }
 
-    // 모든 JacocoReport 작업(= jacocoTestReport 포함) 설정
-    tasks.withType(JacocoReport).configureEach {
-        dependsOn(tasks.withType(Test))
+    // 기본 test만 끝난 뒤 리포트 1회 실행
+    tasks.named('test', Test).configure {
+        finalizedBy('jacocoTestReport')
+    }
+
+    // 3) 리포트 → 검증 순서 고정
+    tasks.named('jacocoTestReport', JacocoReport).configure {
+        dependsOn('test')
 
         reports {
-            xml.required = true   // CI 파싱용
-            csv.required = false
-            html.required = true   // 로컬 열람용
+            xml.required  = true   // CI 파싱용 (PR 코멘트 액션)
+            csv.required  = false
+            html.required = true   // 로컬/아티팩트 열람용
         }
 
-        def javaMainDir = layout.buildDirectory.dir("classes/java/main").get().asFile
+        def javaMainDir = layout.buildDirectory.dir('classes/java/main').get().asFile
 
         classDirectories.setFrom(
                 fileTree(javaMainDir) {
@@ -32,38 +34,37 @@ plugins.withId('jacoco') {
                 }
         )
 
-        finalizedBy(tasks.withType(JacocoCoverageVerification))
+        finalizedBy('jacocoTestCoverageVerification')
     }
 
-    // 모든 커버리지 검증 작업 설정
-    tasks.withType(JacocoCoverageVerification).configureEach {
-        dependsOn(tasks.withType(JacocoReport))
+    tasks.named('jacocoTestCoverageVerification', JacocoCoverageVerification).configure {
+        dependsOn('jacocoTestReport')
 
         violationRules {
             rule {
                 limit {
                     counter = 'LINE'
-                    value = 'COVEREDRATIO'
+                    value   = 'COVEREDRATIO'
                     minimum = 0.00
                 }
             }
             rule {
                 limit {
                     counter = 'BRANCH'
-                    value = 'COVEREDRATIO'
+                    value   = 'COVEREDRATIO'
                     minimum = 0.00
                 }
             }
             rule {
-                element = 'CLASS'
+                element  = 'CLASS'
                 excludes = [
-                        '*.config.*', '*.dto.*', '*.model.*', '*Application',
-                        '*.exception.*', '*.common.*', '*.constant.*', '*.logging.*',
-                        '*.notification.*', '*.test.*', '*.infrastructure.*'
+                        '*.config.*','*.dto.*','*.model.*','*Application',
+                        '*.exception.*','*.common.*','*.constant.*',
+                        '*.logging.*','*.notification.*','*.test.*','*.infrastructure.*'
                 ]
                 limit {
                     counter = 'LINE'
-                    value = 'COVEREDRATIO'
+                    value   = 'COVEREDRATIO'
                     minimum = 0.00
                 }
             }

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -1,0 +1,72 @@
+plugins.withId('jacoco') {
+
+    jacoco {
+        toolVersion = "0.8.13"
+    }
+
+    // 모든 Test 작업 공통 설정
+    tasks.withType(Test).configureEach {
+        useJUnitPlatform()
+        finalizedBy("jacocoTestReport") // test 후 리포트
+    }
+
+    // 모든 JacocoReport 작업(= jacocoTestReport 포함) 설정
+    tasks.withType(JacocoReport).configureEach {
+        dependsOn(tasks.withType(Test))
+
+        reports {
+            xml.required = true   // CI 파싱용
+            csv.required = false
+            html.required = true   // 로컬 열람용
+        }
+
+        def javaMainDir = layout.buildDirectory.dir("classes/java/main").get().asFile
+
+        classDirectories.setFrom(
+                fileTree(javaMainDir) {
+                    exclude(
+                            '**/config/**','**/dto/**','**/model/**','**/*Application.class',
+                            '**/exception/**','**/common/**','**/constant/**',
+                            '**/logging/**','**/notification/**','**/test/**','**/infrastructure/**'
+                    )
+                }
+        )
+
+        finalizedBy(tasks.withType(JacocoCoverageVerification))
+    }
+
+    // 모든 커버리지 검증 작업 설정
+    tasks.withType(JacocoCoverageVerification).configureEach {
+        dependsOn(tasks.withType(JacocoReport))
+
+        violationRules {
+            rule {
+                limit {
+                    counter = 'LINE'
+                    value = 'COVEREDRATIO'
+                    minimum = 0.00
+                }
+            }
+            rule {
+                limit {
+                    counter = 'BRANCH'
+                    value = 'COVEREDRATIO'
+                    minimum = 0.00
+                }
+            }
+            rule {
+                element = 'CLASS'
+                excludes = [
+                        '*.config.*', '*.dto.*', '*.model.*', '*Application',
+                        '*.exception.*', '*.common.*', '*.constant.*', '*.logging.*',
+                        '*.notification.*', '*.test.*', '*.infrastructure.*'
+                ]
+                limit {
+                    counter = 'LINE'
+                    value = 'COVEREDRATIO'
+                    minimum = 0.00
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #101 

## Work Description 📝
- jacoco 를 도입하였습니다.

### jacoco
jacoco 는 테스트 코드 커버리지를 분석해주는 자바의 무료 라이브러리입니다.

인텔리제이의 테스트 커버리지 확인 기능을 통해 테스트 코드의 커버리지를 확인할 수도 있지만, jacoco 를 활용하면 테스트 커버리지 결과를 github action 과 연동할 수도 있고, 커버리지가 특정 수준을 넘지 않는다면 아예 빌드가 실패하도록 하는 기능도 존재하기 때문에 저희 프로젝트의 안정성을 높이는데 도움이 될 것이라 판단하고 적용해보았습니다.

### 테스트 커버리지 최소 수준
보통은 테스트 커버리지를 확인하고, 커버리지가 특정 수치를 넘지 않는다면 빌드가 실패하도록 설정해둘 수 있는데, 아직 테스트가 미흡한 코드들이 존재하기 때문에 이러한 설정은 추후에 테스트 코드들이 좀 더 추가된 이후에 도입하는 것이 좋을 것 같습니다.
따라서 현재는 테스트 커버리지를 0.00, 즉 아무리 테스트가 미흡하더라도 빌드는 항상 성공하도록 설정해두었습니다.

### 테스트 커버리지 검증 파일
테스트 커버리지를 모든 파일에 대해 검증하지는 않도록 설정하였습니다.
dto 클래스, 엔티티 클래스, 예외 클래스, S3 관련 클래스, 알림 설정 관련 클래스, 상수 클래스, 그리고 common 패키지 하위의 클래스 등등은 테스트에 어려움이 있을 것이라 생각했기 때문에 제 판단하에 우선적으로 테스트 커버리지를 검증하지 않도록 제외하였습니다.
이렇게 제외해둔 클래스들 중에도 테스트 커버리지를 검증해보면 좋겠다 싶은 클래스가 있다면 설정만 바꾸면 되니 언제든 이야기해주세요

### 검증 방법
1. **`./gradlew clean test --stacktrace`** 실행

이 명령어를 실행하면 build/reports/jacoco/test/html 하위에 index.html 이라는 파일이 생성됩니다.
이 파일을 열어보면 테스트 커버리지를 확인하실 수 있습니다.
 
<img width="429" height="217" alt="스크린샷 2025-09-02 오전 1 05 48" src="https://github.com/user-attachments/assets/9faeb94b-9277-49c2-a16b-5401522f34cf" />

2. **`open build/reports/jacoco/test/html/index.html`**

이 명령어가 파일을 열람할 수 있는 명령어입니다. 
<img width="1439" height="573" alt="스크린샷 2025-09-02 오전 1 05 29" src="https://github.com/user-attachments/assets/c677dbfe-df0a-464e-95c8-0824b2a2c4f0" />


### github actions 와 연동
테스트 커버리지 결과를 PR에 코멘트로 추가할 수 있도록 설정하였습니다.
<img width="936" height="252" alt="스크린샷 2025-09-02 오전 1 28 32" src="https://github.com/user-attachments/assets/99912844-c4d5-41c2-a5bd-ff97087fd7df" />

## Screenshot 📸

## Uncompleted Tasks 😅
없습니다.

## To Reviewers 📢
jacoco 를 도입해보았으니 모두 테스트 커버리지를 끌어올려서, 이후로는 커버리지 최소 수준을 80 퍼 정도로는 설정할 수 있게되면 좋을 것 같습니다 ㅎㅎ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **테스트**
  * PR마다 자동으로 테스트를 실행하고 결과를 항상 게시합니다.
  * 테스트 리포트를 XML/HTML 형태로 생성하여 확인이 쉬워졌습니다.

* **New Features**
  * PR에 JaCoCo 커버리지 요약을 자동으로 댓글로 게시·업데이트합니다.
  * 생성된 커버리지 HTML을 아티팩트로 보관(7일)합니다.

* **Chores**
  * CI 파이프라인을 빌드 중심에서 테스트 중심으로 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->