### PR TITLE
[Feat] 스웨거에 JWT 인증용 Authorize 버튼 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.7.0")
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/com/kuit/findyou/domain/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/kuit/findyou/domain/inquiry/controller/InquiryController.java
@@ -7,7 +7,6 @@ import com.kuit.findyou.global.common.response.BaseResponse;
 import com.kuit.findyou.global.jwt.annotation.LoginUserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +27,6 @@ public class InquiryController {
             summary = "문의사항 추가 API",
             description = "문의사항 추가 기능을 수행합니다."
     )
-    @Parameter(in = ParameterIn.HEADER, required = true, name = "Authorization", description = "API 엑세스 토큰", example = "Bearer asdf1234")
     @CustomExceptionDescription(DEFAULT)
     @PostMapping
     public BaseResponse<Void> addInquiry(@Parameter(hidden = true) @LoginUserId Long userId,

--- a/src/main/java/com/kuit/findyou/domain/user/controller/UserController.java
+++ b/src/main/java/com/kuit/findyou/domain/user/controller/UserController.java
@@ -14,7 +14,6 @@ import com.kuit.findyou.global.common.response.BaseResponse;
 import com.kuit.findyou.global.jwt.annotation.LoginUserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -156,7 +155,6 @@ public class UserController {
             summary = "마이페이지 프로필 조회 API",
             description = "마이페이지 프로필 조회 기능을 수행합니다."
     )
-    @Parameter(in = ParameterIn.HEADER, required = true, name = "Authorization", description = "API 엑세스 토큰", example = "Bearer asdf1234")
     @CustomExceptionDescription(DEFAULT)
     @GetMapping("/me")
     public BaseResponse<GetUserProfileResponse> getUserProfile(@Parameter(hidden = true) @LoginUserId Long userId){

--- a/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
+++ b/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
@@ -27,8 +27,8 @@ public class SecurityConfig {
         return new MDCLoggingFilter();
     }
 
-    private final String[] PERMIT_URL = {
-            "/api/v2/auth/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
+    private final String[] SWAGGER_URL = {
+            "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
             "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/swagger-ui/index.html",
     };
 
@@ -44,18 +44,20 @@ public class SecurityConfig {
         http
                 .httpBasic((auth)->auth.disable());
 
-        // todo 인증 비활성화
-        // 토큰 기반 인증 비활성화
-        http
-                .authorizeHttpRequests((auth)-> auth
-                        .anyRequest().permitAll());
 
-        // 토큰 기반 인증 활성화
+        // 토큰 기반 인증 비활성화
 //        http
 //                .authorizeHttpRequests((auth)-> auth
-//                        .requestMatchers(PERMIT_URL).permitAll()
-//                        .requestMatchers(HttpMethod.POST, "/api/v2/users").permitAll()
-//                        .anyRequest().authenticated());
+//                        .anyRequest().permitAll());
+
+        // 토큰 기반 인증 활성화
+        http
+                .authorizeHttpRequests((auth)-> auth
+                        .requestMatchers(SWAGGER_URL).permitAll()
+                        .requestMatchers("/api/v2/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v2/users").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v2/users/check/duplicate-nickname").permitAll()
+                        .anyRequest().authenticated());
 
         // 토큰 검증 필터 추가
         http

--- a/src/main/java/com/kuit/findyou/global/config/SwaggerConfig.java
+++ b/src/main/java/com/kuit/findyou/global/config/SwaggerConfig.java
@@ -5,15 +5,17 @@ import com.kuit.findyou.global.common.response.BaseErrorResponse;
 import com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus;
 import com.kuit.findyou.global.common.swagger.ExampleHolder;
 import com.kuit.findyou.global.common.swagger.SwaggerResponseDescription;
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,19 +27,31 @@ import java.util.Set;
 
 import static java.util.stream.Collectors.groupingBy;
 
-@OpenAPIDefinition(
-        info = @Info(
-                title = "찾아유 V2 API 명세서",
-                description = "Springdoc을 이용한 Swagger API 문서입니다.",
-                version = "1.0"
-        )
-)
 @Configuration
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
-        return new OpenAPI();
+        Info info = new Info()
+                .version("1.0")
+                .title("찾아유 V2 API 명세서")
+                .description("Springdoc을 이용한 Swagger API 문서입니다.");
+
+        String jwtSchemeName = "JWT Authentication";
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
     }
 
     @Bean

--- a/src/main/java/com/kuit/findyou/global/jwt/argument_resolver/LoginUserIdArgumentResolver.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/argument_resolver/LoginUserIdArgumentResolver.java
@@ -26,9 +26,6 @@ public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolve
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String token = (String) request.getAttribute(TOKEN_FOR_ARGUMENT_RESOLVER.getValue());
-        if(token == null) {
-            return 1L;
-        }
         Long userId = jwtUtil.getUserId(token);
         log.info("userId = {}",  userId);
         return userId;

--- a/src/test/java/com/kuit/findyou/domain/breed/controller/BreedControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/breed/controller/BreedControllerTest.java
@@ -18,8 +18,6 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import java.util.Map;
-
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.BREED_ANALYSIS_FAILED;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +49,7 @@ class BreedControllerTest {
     @BeforeAll
     void setUp() {
         databaseCleaner.execute();
+        testInitializer.createTestUser();
         testInitializer.createTestBreeds();
         RestAssured.port = port;
     }
@@ -63,7 +62,7 @@ class BreedControllerTest {
         // when
         BreedListResponseDTO response =
                 given()
-                        .header("Authorization", accessToken)
+                        .header("Authorization","Bearer " +  accessToken)
                         .when()
                         .get("/api/v2/breeds")
                         .then()
@@ -92,7 +91,7 @@ class BreedControllerTest {
         // when
         BreedAiDetectionResponseDTO response =
                 given()
-                        .header("Authorization", accessToken)
+                        .header("Authorization", "Bearer " +accessToken)
                         .contentType(ContentType.JSON)
                         .body(request)
                         .when()
@@ -122,7 +121,7 @@ class BreedControllerTest {
 
         // when & then
         given()
-                .header("Authorization", accessToken)
+                .header("Authorization", "Bearer " + accessToken)
                 .contentType(ContentType.JSON)
                 .body(request)
                 .when()

--- a/src/test/java/com/kuit/findyou/domain/city/controller/CityControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/city/controller/CityControllerTest.java
@@ -36,6 +36,7 @@ class CityControllerTest {
     @BeforeAll
     void setUp() {
         databaseCleaner.execute();
+        testInitializer.createTestUser();
         testInitializer.createTestCities();
         RestAssured.port = port;
         accessToken = jwtUtil.createAccessJwt(1L, Role.USER);
@@ -51,7 +52,7 @@ class CityControllerTest {
             // when
             var json =
                     given()
-                            .header("Authorization", accessToken)
+                            .header("Authorization","Bearer " + accessToken)
                             .accept(ContentType.JSON)
                             .when()
                             .get("/api/v2/sidos")
@@ -79,7 +80,7 @@ class CityControllerTest {
             // when
             var json =
                     given()
-                            .header("Authorization", accessToken)
+                            .header("Authorization", "Bearer " +accessToken)
                             .accept(ContentType.JSON)
                             .queryParam("sidoId", sidoId)
                             .when()
@@ -97,7 +98,7 @@ class CityControllerTest {
         @DisplayName("400 Bad Request - 필수 파라미터 누락 시")
         void missingParam() {
             given()
-                    .header("Authorization", accessToken)
+                    .header("Authorization", "Bearer " +accessToken)
                     .accept(ContentType.JSON)
                     .when()
             .get("/api/v2/sigungus") // sidoId 없음
@@ -110,7 +111,7 @@ class CityControllerTest {
         @DisplayName("SIDO_NOT_FOUND 매핑 - 존재하지 않는 sidoId")
         void notFoundSido() {
             given()
-                    .header("Authorization", accessToken)
+                    .header("Authorization", "Bearer " +accessToken)
                     .accept(ContentType.JSON)
                     .queryParam("sidoId", 999999L)
                     .when()


### PR DESCRIPTION
## Related issue 🛠
- closed #103 

## Work Description 📝
- 스웨거 UI에 JWT 인증용 Authorize 버튼을 추가했습니다. 토큰을 등록하면 모든 요청에 대해서 인증이 됩니다.
- 시큐리티 인증을 활성화하였습니다.
- argument resolver를 수정해서 컨트롤러 메서드에 로그인한 사용자의 id만 전달되도록 수정했습니다

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- 없습니다

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 보안
  - 대부분의 API가 인증 필요로 전환되고 공개 경로는 인증/회원가입 및 문서로 제한됩니다.
  - 인증 허용 목록이 정리되어 Swagger/UI 경로와 일부 회원/인증 엔드포인트만 공개됩니다.

- 문서
  - OpenAPI 설정이 프로그램적 구성으로 변경되고 JWT Bearer 보안 스키마가 추가되었습니다.
  - 일부 엔드포인트의 개별 Authorization 헤더 표기가 문서에서 제거되어 일관성 향상.

- 테스트
  - 테스트들이 Bearer 토큰 형식으로 인증 헤더를 사용하도록 갱신되고 테스트 사용자/토큰 생성이 추가됨.

- 작업(Chores)
  - OpenAPI 런타임 의존성 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->