### PR TITLE
[Feat] 신고글 삭제 api 구현

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -102,5 +102,16 @@ public class ReportController {
         return BaseResponse.ok(null);
     }
 
+    @Operation(summary = "신고글 삭제 API", description = "자신이 작성한 신고글(실종/목격)을 삭제합니다.")
+    @CustomExceptionDescription(DELETE_REPORT)
+    @DeleteMapping("/{reportId}")
+    public BaseResponse<Void> deleteReport(
+            @Parameter(description = "삭제할 신고글의 ID") @PathVariable("reportId") Long reportId,
+            @Parameter(hidden = true) @LoginUserId Long userId
+    ) {
+        reportServiceFacade.deleteReport(reportId, userId);
+        return BaseResponse.ok(null);
+    }
+
 }
 

--- a/src/main/java/com/kuit/findyou/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/ReportRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ReportRepository extends JpaRepository<Report, Long> {
@@ -110,5 +111,11 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
         ORDER BY r.id DESC
     """)
     Slice<ReportProjection> findUserReportsByCursor(@Param("userId") Long userId, @Param("lastId") Long lastId, Pageable pageable);
+
+    @Query("SELECT r FROM Report r " +
+            "LEFT JOIN FETCH r.user " +
+            "LEFT JOIN FETCH r.reportImages " +
+            "WHERE r.id = :reportId")
+    Optional<Report> findByIdWithUserAndImages(@Param("reportId") Long reportId);
 }
 

--- a/src/main/java/com/kuit/findyou/domain/report/service/command/DeleteReportService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/command/DeleteReportService.java
@@ -1,0 +1,7 @@
+package com.kuit.findyou.domain.report.service.command;
+
+import com.kuit.findyou.domain.report.model.Report;
+
+public interface DeleteReportService {
+    void deleteReport(Long reportId, Long userId);
+}

--- a/src/main/java/com/kuit/findyou/domain/report/service/command/DeleteReportServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/command/DeleteReportServiceImpl.java
@@ -1,0 +1,54 @@
+package com.kuit.findyou.domain.report.service.command;
+
+import com.kuit.findyou.domain.image.model.ReportImage;
+import com.kuit.findyou.domain.report.model.Report;
+import com.kuit.findyou.domain.report.repository.ReportRepository;
+import com.kuit.findyou.global.common.exception.CustomException;
+import com.kuit.findyou.global.infrastructure.ImageUploader;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
+
+@RequiredArgsConstructor
+@Service
+public class DeleteReportServiceImpl implements DeleteReportService {
+
+    private final ReportRepository reportRepository;
+    private final ImageUploader imageUploader;
+
+    @Override
+    @Transactional
+    public void deleteReport(Long reportId, Long userId) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new CustomException(REPORT_NOT_FOUND));
+
+        if(!report.getUser().getId().equals(userId)){
+            throw new CustomException(MISMATCH_REPORT_USER);
+        }
+        List<ReportImage> imagesToDelete = report.getReportImages();
+
+        //이미지 존재하면 S3에서 삭제
+        if (imagesToDelete != null && !imagesToDelete.isEmpty()) {
+            imagesToDelete.stream()
+                    .map(ReportImage::getImageUrl)
+                    .forEach(imageUrl -> {
+                        String imageKey = extractImageKeyFromUrl(imageUrl);
+                        imageUploader.delete(imageKey);
+                    });
+        }
+        reportRepository.delete(report);
+    }
+    private String extractImageKeyFromUrl(String url) {
+        try {
+            return new URI(url).getPath().substring(1);
+        } catch (URISyntaxException e) {
+            throw new CustomException(BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/kuit/findyou/domain/report/service/command/DeleteReportServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/command/DeleteReportServiceImpl.java
@@ -25,7 +25,7 @@ public class DeleteReportServiceImpl implements DeleteReportService {
     @Override
     @Transactional
     public void deleteReport(Long reportId, Long userId) {
-        Report report = reportRepository.findById(reportId)
+        Report report = reportRepository.findByIdWithUserAndImages(reportId)
                 .orElseThrow(() -> new CustomException(REPORT_NOT_FOUND));
 
         if(!report.getUser().getId().equals(userId)){

--- a/src/main/java/com/kuit/findyou/domain/report/service/facade/ReportServiceFacade.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/facade/ReportServiceFacade.java
@@ -7,6 +7,7 @@ import com.kuit.findyou.domain.report.dto.response.CardResponseDTO;
 import com.kuit.findyou.domain.report.model.ReportTag;
 import com.kuit.findyou.domain.report.service.command.CreateWitnessReportService;
 import com.kuit.findyou.domain.report.service.command.CreateMissingReportService;
+import com.kuit.findyou.domain.report.service.command.DeleteReportService;
 import com.kuit.findyou.domain.report.service.detail.ReportDetailService;
 import com.kuit.findyou.domain.report.service.retrieve.ReportRetrieveService;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ public class ReportServiceFacade {
     private final ReportRetrieveService reportRetrieveService;
     private final CreateWitnessReportService createWitnessReportService;
     private final CreateMissingReportService createMissingReportService;
+    private final DeleteReportService deleteReportService;
 
     public <DTO_TYPE> DTO_TYPE getReportDetail(
             ReportTag tag,
@@ -50,6 +52,10 @@ public class ReportServiceFacade {
 
     public void createWitnessReport(CreateWitnessReportRequest req, Long userId) {
         createWitnessReportService.createWitnessReport(req, userId);
+    }
+
+    public void deleteReport(Long reportId, Long userId) {
+        deleteReportService.deleteReport(reportId, userId);
     }
 }
 

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -46,6 +46,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     WITNESS_REPORT_NOT_FOUND(404, "존재하지 않는 목격 신고글입니다."),
     ILLEGAL_TAG(500, "잘못된 태그값입니다."),
     IMAGE_UPLOAD_HTTPS_REQUIRED(500, "이미지 URL은 https만 허용됩니다."),
+    MISMATCH_REPORT_USER(404, "글 작성자와 삭제 요청자가 동일하지 않습니다."),
+
 
     // 글 이미지 - ReportImage
     IMAGE_UPLOAD_LIMIT_EXCEEDED(400, "이미지는 최대 5개까지 업로드할 수 있습니다."),

--- a/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
@@ -78,6 +78,12 @@ public enum SwaggerResponseDescription {
             BAD_REQUEST
     ))),
 
+    DELETE_REPORT(new LinkedHashSet<>(Set.of(
+            MISMATCH_REPORT_USER,
+            REPORT_NOT_FOUND,
+            BAD_REQUEST
+    ))),
+
     DEFAULT(new LinkedHashSet<>());
 
 

--- a/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
@@ -74,14 +74,12 @@ public enum SwaggerResponseDescription {
     CHANGE_PROFILE_IMAGE(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
             IMAGE_UPLOAD_FAILED,
-            IMAGE_SIZE_EXCEEDED,
-            BAD_REQUEST
+            IMAGE_SIZE_EXCEEDED
     ))),
 
     DELETE_REPORT(new LinkedHashSet<>(Set.of(
             MISMATCH_REPORT_USER,
-            REPORT_NOT_FOUND,
-            BAD_REQUEST
+            REPORT_NOT_FOUND
     ))),
 
     DEFAULT(new LinkedHashSet<>());

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -408,7 +408,8 @@ class ReportControllerTest {
                 .log().all()
                 .statusCode(200)
                 .body("success", equalTo(false))
-                .body("code", equalTo(404));
+                .body("code", equalTo(404))
+                .body("message", containsString("글 작성자와 삭제 요청자가 동일하지 않습니다."));
     }
 
     @Test
@@ -428,6 +429,7 @@ class ReportControllerTest {
                 .log().all()
                 .statusCode(200)
                 .body("success", equalTo(false))
-                .body("code", equalTo(404));
+                .body("code", equalTo(404))
+                .body("message", containsString("존재하지 않는 신고글입니다."));
     }
 }

--- a/src/test/java/com/kuit/findyou/domain/report/service/command/DeleteReportServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/command/DeleteReportServiceImplTest.java
@@ -1,0 +1,117 @@
+package com.kuit.findyou.domain.report.service.command;
+
+import com.kuit.findyou.domain.image.model.ReportImage;
+import com.kuit.findyou.domain.report.model.MissingReport;
+import com.kuit.findyou.domain.report.model.Report;
+import com.kuit.findyou.domain.report.repository.ReportRepository;
+import com.kuit.findyou.domain.user.model.User;
+import com.kuit.findyou.global.common.exception.CustomException;
+import com.kuit.findyou.global.infrastructure.ImageUploader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.MISMATCH_REPORT_USER;
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.REPORT_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class DeleteReportServiceImplTest {
+    @InjectMocks
+    private DeleteReportServiceImpl deleteReportService;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private ImageUploader imageUploader;
+
+    private User user;
+    private Report reportWithoutImages;
+    private Report reportWithImages;
+    private Long userId = 1L;
+    private Long reportId = 10L;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().id(userId).build();
+        reportWithoutImages = MissingReport.builder().user(user).build();
+
+        //이미지 없는 신고글
+        reportWithImages = MissingReport.builder().user(user).build();
+        ReportImage image = ReportImage.createReportImage("https://cdn.findyou.store/image.jpg", reportWithImages);
+    }
+    @Test
+    @DisplayName("이미지가 없는 신고글을 성공적으로 삭제")
+    void deleteReport_WithoutImages_Success() {
+        // given
+        when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportWithoutImages));
+
+        // when
+        deleteReportService.deleteReport(reportId, userId);
+
+        // then
+        verify(reportRepository, times(1)).findById(reportId);
+        // ▼▼▼▼▼ [추가] imageUploader가 호출되지 않았음을 검증 ▼▼▼▼▼
+        verify(imageUploader, never()).delete(anyString());
+        verify(reportRepository, times(1)).delete(reportWithoutImages);
+    }
+
+    @Test
+    @DisplayName("이미지가 있는 신고글을 성공적으로 삭제")
+    void deleteReport_WithImages_Success() {
+        // given
+        when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportWithImages));
+
+        // when
+        deleteReportService.deleteReport(reportId, userId);
+
+        // then
+        verify(reportRepository, times(1)).findById(reportId);
+        // imageUploader의 delete가 1번 호출되었는지 검증
+        verify(imageUploader, times(1)).delete(anyString());
+        verify(reportRepository, times(1)).delete(reportWithImages);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 신고글을 삭제하려 하면 예외 발생")
+    void deleteReport_Fail_ReportNotFound() {
+        // given
+
+        when(reportRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> deleteReportService.deleteReport(reportId, userId))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("exceptionStatus", REPORT_NOT_FOUND);
+
+        //delete 메서드는 호출되지 않아야 함
+        verify(reportRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("다른 사람의 신고글을 삭제하려고 하면 예외가 발생")
+    void deleteReport_Fail_UserMismatch() {
+        // given
+        Long otherUserId = 2L; //글 작성자와 다른 유저
+
+        when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportWithoutImages));
+
+        // when & then
+        //다른 유저 ID로 deleteReport 메서드 실행
+        assertThatThrownBy(() -> deleteReportService.deleteReport(reportId, otherUserId))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("exceptionStatus", MISMATCH_REPORT_USER);
+
+        //delete 메서드는 호출되지 않아야 함
+        verify(reportRepository, never()).delete(any());
+    }
+}

--- a/src/test/java/com/kuit/findyou/domain/report/service/command/DeleteReportServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/command/DeleteReportServiceImplTest.java
@@ -43,11 +43,13 @@ public class DeleteReportServiceImplTest {
     @BeforeEach
     void setUp() {
         user = User.builder().id(userId).build();
-        reportWithoutImages = MissingReport.builder().user(user).build();
 
         //이미지 없는 신고글
+        reportWithoutImages = MissingReport.builder().user(user).build();
+
+        //이미지 있는 신고글
         reportWithImages = MissingReport.builder().user(user).build();
-        ReportImage image = ReportImage.createReportImage("https://cdn.findyou.store/image.jpg", reportWithImages);
+        ReportImage.createReportImage("https://cdn.findyou.store/image.jpg", reportWithImages);
     }
     @Test
     @DisplayName("이미지가 없는 신고글을 성공적으로 삭제")
@@ -60,7 +62,6 @@ public class DeleteReportServiceImplTest {
 
         // then
         verify(reportRepository, times(1)).findById(reportId);
-        // ▼▼▼▼▼ [추가] imageUploader가 호출되지 않았음을 검증 ▼▼▼▼▼
         verify(imageUploader, never()).delete(anyString());
         verify(reportRepository, times(1)).delete(reportWithoutImages);
     }
@@ -95,6 +96,7 @@ public class DeleteReportServiceImplTest {
 
         //delete 메서드는 호출되지 않아야 함
         verify(reportRepository, never()).delete(any());
+        verify(imageUploader, never()).delete(anyString());
     }
 
     @Test
@@ -113,5 +115,6 @@ public class DeleteReportServiceImplTest {
 
         //delete 메서드는 호출되지 않아야 함
         verify(reportRepository, never()).delete(any());
+        verify(imageUploader, never()).delete(anyString());
     }
 }

--- a/src/test/java/com/kuit/findyou/domain/report/service/command/DeleteReportServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/command/DeleteReportServiceImplTest.java
@@ -55,13 +55,13 @@ public class DeleteReportServiceImplTest {
     @DisplayName("이미지가 없는 신고글을 성공적으로 삭제")
     void deleteReport_WithoutImages_Success() {
         // given
-        when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportWithoutImages));
+        when(reportRepository.findByIdWithUserAndImages(reportId)).thenReturn(Optional.of(reportWithoutImages));
 
         // when
         deleteReportService.deleteReport(reportId, userId);
 
         // then
-        verify(reportRepository, times(1)).findById(reportId);
+        verify(reportRepository, times(1)).findByIdWithUserAndImages(reportId);
         verify(imageUploader, never()).delete(anyString());
         verify(reportRepository, times(1)).delete(reportWithoutImages);
     }
@@ -70,13 +70,13 @@ public class DeleteReportServiceImplTest {
     @DisplayName("이미지가 있는 신고글을 성공적으로 삭제")
     void deleteReport_WithImages_Success() {
         // given
-        when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportWithImages));
+        when(reportRepository.findByIdWithUserAndImages(reportId)).thenReturn(Optional.of(reportWithImages));
 
         // when
         deleteReportService.deleteReport(reportId, userId);
 
         // then
-        verify(reportRepository, times(1)).findById(reportId);
+        verify(reportRepository, times(1)).findByIdWithUserAndImages(reportId);
         // imageUploader의 delete가 1번 호출되었는지 검증
         verify(imageUploader, times(1)).delete(anyString());
         verify(reportRepository, times(1)).delete(reportWithImages);
@@ -87,7 +87,7 @@ public class DeleteReportServiceImplTest {
     void deleteReport_Fail_ReportNotFound() {
         // given
 
-        when(reportRepository.findById(anyLong())).thenReturn(Optional.empty());
+        when(reportRepository.findByIdWithUserAndImages(anyLong())).thenReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> deleteReportService.deleteReport(reportId, userId))
@@ -105,7 +105,7 @@ public class DeleteReportServiceImplTest {
         // given
         Long otherUserId = 2L; //글 작성자와 다른 유저
 
-        when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportWithoutImages));
+        when(reportRepository.findByIdWithUserAndImages(reportId)).thenReturn(Optional.of(reportWithoutImages));
 
         // when & then
         //다른 유저 ID로 deleteReport 메서드 실행


### PR DESCRIPTION
## Related issue 🛠
- closed #109 

## Work Description 📝
- 실종 신고글 / 목격 신고글 삭제 기능을 구현했습니다.
- 신고글 삭제 시 해당 신고글에 함께 업로드된 이미지또한 삭제되도록 구현했습니다.
- reportId를 이용해 MissingReport와 WitnessReport 구분 없이 공통으로 삭제 처리하도록 했습니다.
- 요청을 보낸 사용자가 글을 작성한 유저와 일치하는 경우에만 삭제를 허용합니다. 일치하지 않는 경우엔 MISMATCH_REPORT_USER 예외가 발생합니다.
- 신고글에 첨부된 이미지가 있는 경우 -> S3 버킷에서 해당 파일을 함께 삭제합니다.
   - report.getReportImages()를 통해 연결된 이미지 목록 조회
   - 각 URL에서 파일 키 추출
   - ImageUploader를 통해 S3 객체 삭제 후 DB 트랜잭션 커밋하여 데이터 정합성을 보장합니다.



## Screenshot 📸
실종 신고글 등록
<img width="450" height="350" alt="image" src="https://github.com/user-attachments/assets/bf12781e-85af-48c1-a5a5-644f74a2f870" />

<img width="450" height="350" alt="image" src="https://github.com/user-attachments/assets/acfdd34a-2a9e-427b-8167-1782ac76359a" />

해당 신고글 삭제 
<img width="450" height="350" alt="image" src="https://github.com/user-attachments/assets/c2b8cfeb-4162-4e67-b54b-3357f2ab5266" />

<img width="450" height="350" alt="image" src="https://github.com/user-attachments/assets/a6566d5a-3784-4a0a-bffc-bda33409e5de" />


## Uncompleted Tasks 😅

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 신고글 삭제 기능 추가: 본인이 작성한 신고글을 DELETE /api/v2/reports/{reportId}로 삭제 가능하며, 연관 이미지도 함께 삭제됩니다.
  - 삭제 시 작성자 검증 추가(작성자 불일치 시 404 반환).

- **Documentation**
  - API 문서에 신고글 삭제 엔드포인트 및 관련 오류 응답 사례(작성자 불일치, 미존재, 잘못된 요청 등) 추가.

- **Tests**
  - 컨트롤러·서비스·리포지토리 테스트 보강: 성공, 작성자 불일치, 미존재, 이미지 포함/미포함, 연관 엔티티 cascade 삭제 시나리오 검증.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->