### PR TITLE
[Fix] User 엔티티 삭제를 hard delete로 변경 

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/user/model/User.java
+++ b/src/main/java/com/kuit/findyou/domain/user/model/User.java
@@ -25,8 +25,6 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@SQLDelete(sql = "UPDATE users SET status = 'N' WHERE id = ?")
-@SQLRestriction("status = 'Y'")
 public class User extends BaseEntity {
 
     @Id


### PR DESCRIPTION
## Related issue 🛠
- closed #113

## Work Description 📝
- User 엔티티의 삭제를 Soft Delete방식으로 변경했습니다
- 회원탈퇴 후 다시 회원가입할 때 생기는 unique 제약 조건 위반 현상이 발견되었는데, 탈퇴한 회원정보는 더이상 유지할 필요가 없다는 팀의 결론에 따라 User 엔티티는 hard delete하기로 했습니다.
- DB 테이블 생성 쿼리에 ON DELETE CASCADE가 존재하므로 별도의 JPA 설정은 추가하지 않았습니다

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- 없습니다

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 사용자 계정 삭제 시 더 이상 ‘비활성화’로 전환되지 않고 데이터가 영구적으로 제거됩니다. 삭제 후 복구가 불가능하니 유의해 주세요.
  * 사용자 목록/검색에서 이전처럼 자동으로 ‘활성 사용자만’ 표시되지 않을 수 있습니다. 필요한 경우 필터를 적용해 원하는 사용자만 보이도록 설정하세요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->