### PR TITLE
[Chore] 로컬/테스트 환경 DB를 H2 -> MySQL 로 전환

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -10,6 +10,10 @@ permissions:
   checks: write         # check-runs 작성 허용
   pull-requests: write  # PR 코멘트 작성 허용
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest     # OS 지정
@@ -20,6 +24,22 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+
+      # Gradle 캐싱 추가
+      - name: 🚀 Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: 🐳 Verify Docker is available
+        run: |
+          docker --version
+          docker info
 
       - name: 👏🏻 grant execute permission for gradlew
         run: chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -45,15 +45,19 @@ dependencies {
 	// Devtools
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
-	// h2
-	runtimeOnly 'com.h2database:h2'
-
 	// MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Testcontainers BOM
+	testImplementation("org.testcontainers:testcontainers:1.20.2")
+	testImplementation("org.testcontainers:junit-jupiter:1.20.2")
+	testImplementation("org.testcontainers:mysql:1.20.2")
+	testImplementation("org.springframework.boot:spring-boot-testcontainers:3.5.0")
+
 
 	// Mock
 	testImplementation 'org.mockito:mockito-core'
@@ -84,10 +88,6 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
-	// Testcontainer
-	testImplementation 'org.testcontainers:testcontainers:1.19.3'
-	testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
 
 	// Wiremock
 	testImplementation("org.wiremock:wiremock-standalone:3.2.0")

--- a/src/main/java/com/kuit/findyou/domain/report/repository/InterestReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/InterestReportRepository.java
@@ -15,12 +15,6 @@ import java.util.List;
 public interface InterestReportRepository extends JpaRepository<InterestReport, Long> {
 
 
-    @Query(value = "SELECT EXISTS (" +
-            "SELECT 1 FROM interest_reports " +
-            "WHERE report_id = :reportId " +
-            "AND user_id = :userId " +
-            "AND status = 'Y'" +
-            ")", nativeQuery = true)
     boolean existsByReportIdAndUserId(@Param("reportId") Long reportId,
                                       @Param("userId") Long userId);
 

--- a/src/main/java/com/kuit/findyou/domain/report/service/detail/ReportDetailServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/detail/ReportDetailServiceImpl.java
@@ -33,7 +33,7 @@ public class ReportDetailServiceImpl implements ReportDetailService {
     private final InterestReportRepository interestReportRepository;
     private final UserRepository userRepository;
 
-    @Transactional(readOnly = true)
+    @Transactional
     @SuppressWarnings("unchecked")
     public <REPORT_TYPE extends Report, DTO_TYPE> DTO_TYPE getReportDetail(ReportTag tag, Long reportId, Long userId) {
         ReportDetailStrategy<REPORT_TYPE, DTO_TYPE> strategy =

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
     url: ${LOCAL_DATASOURCE_URL}
     username: ${LOCAL_DATASOURCE_USERNAME}
     password: ${LOCAL_DATASOURCE_PASSWORD}
-    driver-class-name: org.h2.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: update
@@ -29,7 +29,7 @@ spring:
         format_sql: true
         show_sql: true
         highlight_sql: true
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.MySQL8Dialect
   flyway:
     enabled: false
 ---

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
         format_sql: true
         show_sql: true
         highlight_sql: true
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MySQLDialect
   flyway:
     enabled: false
 ---
@@ -51,7 +51,7 @@ spring:
         format_sql: true
         show_sql: true
         highlight_sql: true
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MySQLDialect
   flyway:
     enabled: true
     locations: classpath:db/migration
@@ -71,9 +71,7 @@ spring:
       ddl-auto: validate
     properties:
       hibernate:
-        format_sql: true
-        show_sql: true
-        highlight_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
   flyway:
     enabled: true
     locations: classpath:db/migration

--- a/src/test/java/com/kuit/findyou/FindyouApplicationTests.java
+++ b/src/test/java/com/kuit/findyou/FindyouApplicationTests.java
@@ -1,11 +1,18 @@
 package com.kuit.findyou;
 
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
 class FindyouApplicationTests {
 
 	@Test

--- a/src/test/java/com/kuit/findyou/domain/animalProtection/controller/AnimalCenterControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/animalProtection/controller/AnimalCenterControllerTest.java
@@ -3,6 +3,7 @@ package com.kuit.findyou.domain.animalProtection.controller;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import static io.restassured.RestAssured.given;
@@ -21,6 +23,7 @@ import static org.hamcrest.Matchers.*;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
 public class AnimalCenterControllerTest {
     @LocalServerPort
     int port;

--- a/src/test/java/com/kuit/findyou/domain/animalProtection/repository/AnimalCenterRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/animalProtection/repository/AnimalCenterRepositoryTest.java
@@ -2,10 +2,13 @@ package com.kuit.findyou.domain.animalProtection.repository;
 
 import com.kuit.findyou.domain.information.model.AnimalCenter;
 import com.kuit.findyou.domain.information.repository.AnimalCenterRepository;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -15,6 +18,8 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @DataJpaTest
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class AnimalCenterRepositoryTest {
     @Autowired
     private AnimalCenterRepository animalCenterRepository;

--- a/src/test/java/com/kuit/findyou/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/controller/AuthControllerTest.java
@@ -10,6 +10,7 @@ import com.kuit.findyou.domain.user.repository.UserRepository;
 import com.kuit.findyou.global.common.response.BaseErrorResponse;
 import com.kuit.findyou.global.common.response.BaseResponse;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import com.kuit.findyou.global.jwt.util.JwtTokenType;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
 import io.restassured.RestAssured;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.GUEST_LOGIN_FAILED;
@@ -28,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
 class AuthControllerTest {
     @LocalServerPort
     int port;

--- a/src/test/java/com/kuit/findyou/domain/breed/controller/BreedControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/breed/controller/BreedControllerTest.java
@@ -6,6 +6,7 @@ import com.kuit.findyou.domain.breed.dto.response.BreedListResponseDTO;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import com.kuit.findyou.global.external.client.OpenAiClient;
 import com.kuit.findyou.global.external.exception.OpenAiClientException;
 import com.kuit.findyou.global.external.exception.OpenAiResponseValidatingException;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -32,6 +34,7 @@ import static org.mockito.Mockito.when;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
 class BreedControllerTest {
 
     @LocalServerPort

--- a/src/test/java/com/kuit/findyou/domain/city/controller/CityControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/city/controller/CityControllerTest.java
@@ -3,6 +3,7 @@ package com.kuit.findyou.domain.city.controller;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
@@ -22,6 +24,7 @@ import static org.hamcrest.Matchers.*;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
 class CityControllerTest {
 
     @LocalServerPort

--- a/src/test/java/com/kuit/findyou/domain/city/repository/SigunguRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/city/repository/SigunguRepositoryTest.java
@@ -2,12 +2,15 @@ package com.kuit.findyou.domain.city.repository;
 
 import com.kuit.findyou.domain.city.model.Sido;
 import com.kuit.findyou.domain.city.model.Sigungu;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +22,8 @@ import static org.assertj.core.api.Assertions.*;
 @DataJpaTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class SigunguRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/kuit/findyou/domain/home/controller/HomeControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/home/controller/HomeControllerTest.java
@@ -7,6 +7,7 @@ import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
 import com.kuit.findyou.global.config.RedisTestContainersConfig;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.*;
@@ -26,7 +27,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Import(RedisTestContainersConfig.class)
+@Import({RedisTestContainersConfig.class, TestDatabaseConfig.class})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")

--- a/src/test/java/com/kuit/findyou/domain/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/image/controller/ImageControllerTest.java
@@ -5,6 +5,7 @@ import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.global.common.response.BaseResponse;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import com.kuit.findyou.global.infrastructure.FileUploadingFailedException;
 import com.kuit.findyou.global.infrastructure.ImageUploader;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -36,6 +38,7 @@ import static org.mockito.Mockito.when;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
 class ImageControllerTest {
 
     @LocalServerPort
@@ -58,6 +61,7 @@ class ImageControllerTest {
         databaseCleaner.execute();
         RestAssured.port = port;
     }
+
     @Test
     @DisplayName("여러 개의 이미지를 업로드하고 CDN URL 목록을 반환")
     void uploadImages_Success() throws Exception {

--- a/src/test/java/com/kuit/findyou/domain/information/controller/InformationControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/information/controller/InformationControllerTest.java
@@ -5,6 +5,7 @@ import com.kuit.findyou.domain.information.dto.GetVolunteerWorksResponse;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
@@ -26,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
 class InformationControllerTest {
     @LocalServerPort
     int port;

--- a/src/test/java/com/kuit/findyou/domain/information/repository/AnimalDepartmentRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/information/repository/AnimalDepartmentRepositoryTest.java
@@ -3,11 +3,13 @@ package com.kuit.findyou.domain.information.repository;
 import com.kuit.findyou.domain.information.model.AnimalDepartment;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
@@ -21,8 +23,9 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @DataJpaTest
 @Transactional
-@Import({DatabaseCleaner.class, TestInitializer.class})
+@Import({DatabaseCleaner.class, TestInitializer.class, TestDatabaseConfig.class})
 @ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class AnimalDepartmentRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/kuit/findyou/domain/information/repository/VolunteerWorkRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/information/repository/VolunteerWorkRepositoryTest.java
@@ -2,10 +2,12 @@ package com.kuit.findyou.domain.information.repository;
 
 import com.kuit.findyou.domain.information.model.VolunteerWork;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
@@ -23,8 +25,9 @@ import static org.assertj.core.api.Assertions.*;
 
 @DataJpaTest
 @Transactional
-@Import(DatabaseCleaner.class)
+@Import({DatabaseCleaner.class, TestDatabaseConfig.class})
 @ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class VolunteerWorkRepositoryTest {
     @Autowired
     private VolunteerWorkRepository volunteerWorkRepository;
@@ -71,6 +74,8 @@ class VolunteerWorkRepositoryTest {
                 .volunteerStartAt(LocalDateTime.of(2025, 1, 3, 5, 0))
                 .volunteerEndAt(LocalDateTime.of(2025, 1, 4, 6, 0))
                 .webLink("www.web.link")
+                .registerNumber(String.valueOf(i))
+                .runId((long) i)
                 .build();
     }
 

--- a/src/test/java/com/kuit/findyou/domain/inquiry/controller/InquiryControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/inquiry/controller/InquiryControllerTest.java
@@ -6,6 +6,7 @@ import com.kuit.findyou.domain.inquiry.repository.InquiryRepository;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
@@ -29,6 +31,7 @@ import static org.hamcrest.Matchers.equalTo;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
 class InquiryControllerTest {
     @LocalServerPort
     int port;

--- a/src/test/java/com/kuit/findyou/domain/recommendation/controller/RecommendedContentControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/recommendation/controller/RecommendedContentControllerTest.java
@@ -9,6 +9,7 @@ import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
@@ -32,6 +34,7 @@ import static org.hamcrest.Matchers.*;
 )
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
 public class RecommendedContentControllerTest {
 
     @LocalServerPort

--- a/src/test/java/com/kuit/findyou/domain/recommendation/repository/RecommendedNewsRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/recommendation/repository/RecommendedNewsRepositoryTest.java
@@ -2,11 +2,14 @@ package com.kuit.findyou.domain.recommendation.repository;
 
 import com.kuit.findyou.domain.information.model.RecommendedNews;
 import com.kuit.findyou.domain.information.repository.RecommendedNewsRepository;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +20,8 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @DataJpaTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class RecommendedNewsRepositoryTest {
     @Autowired
     private RecommendedNewsRepository newsRepository;

--- a/src/test/java/com/kuit/findyou/domain/recommendation/repository/RecommendedVideoRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/recommendation/repository/RecommendedVideoRepositoryTest.java
@@ -2,10 +2,13 @@ package com.kuit.findyou.domain.recommendation.repository;
 
 import com.kuit.findyou.domain.information.model.RecommendedVideo;
 import com.kuit.findyou.domain.information.repository.RecommendedVideoRepository;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +19,8 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @DataJpaTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class RecommendedVideoRepositoryTest {
     @Autowired
     private RecommendedVideoRepository videoRepository;

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -6,6 +6,7 @@ import com.kuit.findyou.domain.report.dto.request.ReportViewType;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import com.kuit.findyou.global.infrastructure.ImageUploader;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
 import io.restassured.RestAssured;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -29,6 +31,7 @@ import static org.hamcrest.Matchers.*;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
 class ReportControllerTest {
 
     @MockitoBean
@@ -57,7 +60,6 @@ class ReportControllerTest {
     void getProtectingReportDetail() {
         // 작성자의 엑세스 토큰 생성
         User reportWriter = testInitializer.userWith3InterestReportsAnd2ViewedReports();
-
 
         String accessToken = jwtUtil.createAccessJwt(reportWriter.getId(), reportWriter.getRole());
 

--- a/src/test/java/com/kuit/findyou/domain/report/repository/InterestReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/InterestReportRepositoryTest.java
@@ -7,6 +7,7 @@ import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
@@ -28,9 +30,10 @@ import static org.assertj.core.api.Assertions.*;
 
 
 @DataJpaTest
-@Import({TestInitializer.class})
+@Import({TestInitializer.class, TestDatabaseConfig.class})
 @Transactional
 @ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class InterestReportRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/kuit/findyou/domain/report/repository/MissingReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/MissingReportRepositoryTest.java
@@ -8,13 +8,16 @@ import com.kuit.findyou.domain.report.model.Sex;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceUnitUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +29,8 @@ import static org.assertj.core.api.Assertions.*;
 @DataJpaTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class MissingReportRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepositoryTest.java
@@ -9,12 +9,15 @@ import com.kuit.findyou.domain.report.model.Sex;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +30,8 @@ import static org.assertj.core.api.Assertions.*;
 @DataJpaTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class ProtectingReportRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/kuit/findyou/domain/report/repository/ReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/ReportRepositoryTest.java
@@ -6,11 +6,13 @@ import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
@@ -26,9 +28,10 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.*;
 
 @DataJpaTest
-@Import({ TestInitializer.class, DatabaseCleaner.class })
+@Import({ TestInitializer.class, DatabaseCleaner.class, TestDatabaseConfig.class})
 @Transactional
 @ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class ReportRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/kuit/findyou/domain/report/repository/ViewedReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/ViewedReportRepositoryTest.java
@@ -4,12 +4,15 @@ import com.kuit.findyou.domain.report.model.*;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
@@ -25,6 +28,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @DataJpaTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class ViewedReportRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/kuit/findyou/domain/report/repository/WitnessReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/WitnessReportRepositoryTest.java
@@ -7,12 +7,15 @@ import com.kuit.findyou.domain.report.model.WitnessReport;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +27,8 @@ import static org.assertj.core.api.Assertions.*;
 @DataJpaTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class WitnessReportRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/kuit/findyou/domain/report/strategy/MissingReportDetailStrategyTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/strategy/MissingReportDetailStrategyTest.java
@@ -8,13 +8,16 @@ import com.kuit.findyou.domain.report.repository.MissingReportRepository;
 import com.kuit.findyou.domain.report.service.detail.strategy.MissingReportDetailStrategy;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +29,8 @@ import static org.assertj.core.api.Assertions.*;
 @DataJpaTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class MissingReportDetailStrategyTest {
 
     @Autowired

--- a/src/test/java/com/kuit/findyou/domain/report/strategy/ProtectingReportDetailStrategyTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/strategy/ProtectingReportDetailStrategyTest.java
@@ -9,13 +9,16 @@ import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
 import com.kuit.findyou.domain.report.service.detail.strategy.ProtectingReportDetailStrategy;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +30,8 @@ import static org.assertj.core.api.Assertions.*;
 @DataJpaTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class ProtectingReportDetailStrategyTest {
 
     @Autowired

--- a/src/test/java/com/kuit/findyou/domain/report/strategy/WitnessReportDetailStrategyTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/strategy/WitnessReportDetailStrategyTest.java
@@ -7,12 +7,15 @@ import com.kuit.findyou.domain.report.repository.WitnessReportRepository;
 import com.kuit.findyou.domain.report.service.detail.strategy.WitnessReportDetailStrategy;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +27,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class WitnessReportDetailStrategyTest {
 
     @Autowired

--- a/src/test/java/com/kuit/findyou/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/user/controller/UserControllerTest.java
@@ -12,6 +12,7 @@ import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -46,6 +48,7 @@ import static org.mockito.Mockito.*;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
+@Import(TestDatabaseConfig.class)
 class UserControllerTest {
 
     @LocalServerPort

--- a/src/test/java/com/kuit/findyou/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/user/repository/UserRepositoryTest.java
@@ -6,11 +6,13 @@ import com.kuit.findyou.domain.report.model.*;
 import com.kuit.findyou.domain.report.repository.*;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
+import com.kuit.findyou.global.config.TestDatabaseConfig;
 import jakarta.persistence.EntityManager;
 import com.kuit.findyou.global.common.util.TestInitializer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
@@ -24,8 +26,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 @Transactional
-@Import(TestInitializer.class)
+@Import({TestInitializer.class, TestDatabaseConfig.class})
 @ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class UserRepositoryTest {
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/com/kuit/findyou/global/common/util/DatabaseCleaner.java
+++ b/src/test/java/com/kuit/findyou/global/common/util/DatabaseCleaner.java
@@ -1,41 +1,60 @@
 package com.kuit.findyou.global.common.util;
 
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.Table;
-import jakarta.persistence.metamodel.Type;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
-
 
 @Component
 public class DatabaseCleaner {
 
-    private final EntityManager entityManager;
-    private final List<String> tableNames;
+    private final EntityManager em;
 
-    public DatabaseCleaner(final EntityManager entityManager) {
-        this.entityManager = entityManager;
-        this.tableNames = entityManager.getMetamodel()
-                .getEntities()
-                .stream()
-                .map(Type::getJavaType)
-                .map(javaType -> javaType.getAnnotation(Table.class))
-                .map(Table::name)
-                .toList();
+    private static final List<String> EXCLUDED_TABLES = List.of(
+            "flyway_schema_history" // Flyway 사용 시 기본 제외
+    );
+
+    public DatabaseCleaner(EntityManager em) {
+        this.em = em;
     }
 
     @Transactional
     public void execute() {
-        entityManager.flush();
+        // 현재 DB 스키마명 조회
+        String schema = (String) em.createNativeQuery("SELECT DATABASE()").getSingleResult();
 
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        // 현재 스키마의 모든 물리 테이블명 조회
+        @SuppressWarnings("unchecked")
+        List<String> tableNames = em.createNativeQuery("""
+                SELECT TABLE_NAME
+                FROM INFORMATION_SCHEMA.TABLES
+                WHERE TABLE_SCHEMA = :schema
+                  AND TABLE_TYPE = 'BASE TABLE'
+                """)
+                .setParameter("schema", schema)
+                .getResultList();
 
-        for (String tableName : tableNames) {
-            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName + " RESTART IDENTITY").executeUpdate();
+        // 제외 목록 제거
+        List<String> targets = new ArrayList<>();
+        for (String t : tableNames) {
+            if (!EXCLUDED_TABLES.contains(t)) {
+                targets.add(t);
+            }
         }
 
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+        // FK 체크 끄기
+        em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+        try {
+            // 모든 테이블 TRUNCATE (스키마.테이블로 지정, 백틱으로 이스케이프)
+            for (String table : targets) {
+                String sql = "TRUNCATE TABLE `" + schema + "`.`" + table + "`";
+                em.createNativeQuery(sql).executeUpdate();
+            }
+        } finally {
+            // FK 체크 다시 켜기 (예외가 나도 꼭 실행)
+            em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+        }
     }
 }

--- a/src/test/java/com/kuit/findyou/global/common/util/TestInitializer.java
+++ b/src/test/java/com/kuit/findyou/global/common/util/TestInitializer.java
@@ -191,7 +191,8 @@ public class TestInitializer {
         createTestAnimalCenters();
         return centerUser;
     }
-    public void createTestVolunteerWorks(int number){
+
+    public void createTestVolunteerWorks(int number) {
         IntStream.rangeClosed(1, number).forEach(i -> {
             VolunteerWork volunteerWork = VolunteerWork.builder()
                     .institution("보호센터" + i)
@@ -201,6 +202,8 @@ public class TestInitializer {
                     .volunteerStartAt(LocalDateTime.of(2025, 1, 3, 5, 0))
                     .volunteerEndAt(LocalDateTime.of(2025, 1, 3, 6, 0))
                     .webLink("www.web.link")
+                    .registerNumber(String.valueOf(i))
+                    .runId((long) i)
                     .build();
 
             volunteerWorkRepository.save(volunteerWork);
@@ -313,8 +316,8 @@ public class TestInitializer {
         protectingReportRepository.save(protectingReport);
     }
 
-    public Report createReportByLatLngAndTag(User testUser, Double lat, Double lng, ReportTag tag){
-        if (tag == ReportTag.MISSING){
+    public Report createReportByLatLngAndTag(User testUser, Double lat, Double lng, ReportTag tag) {
+        if (tag == ReportTag.MISSING) {
             MissingReport missingReport = MissingReport.createMissingReport(
                     "골든 리트리버",
                     "개",
@@ -333,8 +336,7 @@ public class TestInitializer {
             );
             missingReportRepository.save(missingReport);
             return missingReport;
-        }
-        else if(tag == ReportTag.WITNESS){
+        } else if (tag == ReportTag.WITNESS) {
             WitnessReport witnessReport = WitnessReport.createWitnessReport(
                     "믹스견",
                     "개",
@@ -351,8 +353,7 @@ public class TestInitializer {
             );
             witnessReportRepository.save(witnessReport);
             return witnessReport;
-        }
-        else if(tag == ReportTag.PROTECTING){
+        } else if (tag == ReportTag.PROTECTING) {
             ProtectingReport protectingReport = ProtectingReport.createProtectingReport(
                     "페르시안",
                     "고양이",

--- a/src/test/java/com/kuit/findyou/global/config/TestDatabaseConfig.java
+++ b/src/test/java/com/kuit/findyou/global/config/TestDatabaseConfig.java
@@ -1,0 +1,19 @@
+package com.kuit.findyou.global.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.MySQLContainer;
+
+@TestConfiguration
+public class TestDatabaseConfig {
+
+    @Bean
+    @ServiceConnection
+    public MySQLContainer<?> mysqlContainer() {
+        return new MySQLContainer<>("mysql:8.0.39")
+                .withDatabaseName("testdb")
+                .withUsername("test")
+                .withPassword("test");
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,7 +9,7 @@ spring:
         format_sql: true
         show_sql: true
         highlight_sql: true
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MySQLDialect
   flyway:
     enabled: true
     locations: classpath:db/migration

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,20 +1,18 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:findyouv2-test;DB_CLOSE_DELAY=-1
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true
         show_sql: true
         highlight_sql: true
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.MySQL8Dialect
   flyway:
-    enabled: false
+    enabled: true
+    locations: classpath:db/migration
   servlet:
     multipart:
       max-file-size: 30MB      # 파일 하나당 최대 30MB


### PR DESCRIPTION
## Related issue 🛠
- closed #115 

## Work Description 📝
- 로컬/테스트 DB 를 MySQL 로 변환하였습니다.

### TestContainer 사용
TestContainer 를 사용하면 별도의 datasource 설정 없이 테스트 시에 MySQL 환경을 세팅할 수 있다는 것을 알게되었습니다.
docker 로부터 이미지를 pull 받아온 후, 그것을 기반으로 MySQL 컨테이너를 띄워 환경을 조성하고 테스트를 진행하는 방식입니다.
CI 시에는, github actions 가 돌아가는 컴퓨터에 docker 가 자동으로 내장되어있기에 별도의 설정을 할 필요가 없고, 로컬에서 테스트를 돌릴 때에도 여러분 컴퓨터에 도커를 깔고(이미 깔려있을 것이라 생각합니다.) 실행시켜준 상태로 테스트를 실행하면 정상적으로 동작합니다.

### DatabaseCleaner 변경
H2 -> MySQL 로 변하면서 쿼리문법에도 변화가 생겼기에, DatabaseCleaner 로직도 그에 맞게 변경해주었습니다.

### 주의사항
주의사항이 두 가지 있습니다.

#### 주의사항 1
우선 현재 테스트 컨테이너를 활용하기 위해 TestDatabaseConfig 라는 설정 클래스를 만들어두었습니다.
다만 이 설정 파일은 Spring 이 자동으로 스캔하지 않기 때문에, 해당 설정이 필요한 클래스에는 반드시 이 **`TestDatabaseConfig`** 클래스를 import 시켜주셔야합니다.

해당 설정이 필요한 클래스는 실제로 DB 를 띄워서 테스트해야하는 클래스들이라고 생각하시면 되고, 그 예로 다음과 같은 클래스들이 있습니다.

1. ~~ControllerTest -> 컨트롤러 통합 테스트 (실제로 DB를 띄워서 테스트하기 때문)
<img width="593" height="114" alt="스크린샷 2025-09-08 오후 9 24 02" src="https://github.com/user-attachments/assets/d3479350-5458-4edb-882d-3fcfe4a94879" />

2. ~~RepositoryTest -> @DataJpaTest 를 활용하면 실제로 DB 를 띄우고 테스트하기 때문
<img width="597" height="128" alt="스크린샷 2025-09-08 오후 9 24 53" src="https://github.com/user-attachments/assets/56950347-93fc-4049-b01f-b917ea017ca7" />

3. 그 외에도 실제로 DB 를 띄워야하는 테스트 클래스들 

반면, 서비스 클래스들, 헬퍼 클래스들과 같이 DB 의 동작을 모킹하는 경우는 Import 해줄 필요가 없습니다.

#### 주의사항 2
@DataJpaTest 를 수행할 때 **`@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)`** 이 옵션을 명시해주셔야합니다.
그러지 않는 경우 테스트시에 자동으로 H2 데이터베이스를 사용하는 경우를 목격한 적이 있습니다. 따라서 꼭 잊지 않고 해당 설정을 붙여주시는 것이 좋습니다.
<img width="606" height="136" alt="스크린샷 2025-09-08 오후 9 26 48" src="https://github.com/user-attachments/assets/eaf1a93c-e7db-4f0c-9ed8-b8572e0acf67" />

## Screenshot 📸

## Uncompleted Tasks 😅

## To Reviewers 📢
이렇게 환경을 구성함으로써, 테스트를 위해 별도로 로컬 컴퓨터에서 MySQL 유저를 새롭게 만들어준다거나 귀찮은 설정을 해줄 필요가 없어졌습니다. 
추가적인 테스트를 작성하시게 될 때에는 위에 작성한 내용을 꼭 유념하시면 좋을 것 같습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능/개선
  - 데이터베이스를 MySQL로 일원화해 환경 간 일관성과 성능/안정성을 강화했습니다.
  - 보고서 상세 조회 시 조회 이력이 안정적으로 반영되도록 처리 흐름을 개선했습니다.
  - 관심 상태 판별 기준을 정비해 일부 화면의 표시가 더 일관되게 보일 수 있습니다.
- 테스트
  - 테스트 환경을 컨테이너 기반 MySQL로 전환해 재현성과 신뢰도를 높였습니다.
- 작업/인프라
  - CI 안정화: 중복 실행 자동 취소, Gradle 캐시 도입, Docker 가용성 사전 점검 추가.
  - 관련 라이브러리 의존성을 최신으로 정비했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->