### PR TITLE
[Refactor] 공공데이터 장애 대응 로직 구현

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/report/service/sync/MissingReportSyncServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/sync/MissingReportSyncServiceImpl.java
@@ -9,6 +9,7 @@ import com.kuit.findyou.domain.report.dto.SyncResult;
 import com.kuit.findyou.domain.report.model.MissingReport;
 import com.kuit.findyou.domain.report.model.ReportTag;
 import com.kuit.findyou.domain.report.repository.MissingReportRepository;
+import com.kuit.findyou.global.common.exception.CustomException;
 import com.kuit.findyou.global.external.client.KakaoCoordinateClient;
 import com.kuit.findyou.global.external.client.MissingAnimalApiClient;
 import com.kuit.findyou.global.external.dto.MissingAnimalItemDTO;
@@ -22,6 +23,8 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.MISSING_REPORT_SYNC_FAILED;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -52,6 +55,7 @@ public class MissingReportSyncServiceImpl implements MissingReportSyncService {
             logSyncResult(syncResult, startTime);
         } catch (Exception e) {
             log.error("[분실 동물 데이터 동기화 실패]", e);
+            throw new CustomException(MISSING_REPORT_SYNC_FAILED);
         }
     }
 

--- a/src/main/java/com/kuit/findyou/domain/report/service/sync/ProtectingReportSyncServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/sync/ProtectingReportSyncServiceImpl.java
@@ -7,6 +7,8 @@ import com.kuit.findyou.domain.report.dto.SyncResult;
 import com.kuit.findyou.domain.report.model.ProtectingReport;
 import com.kuit.findyou.domain.report.model.ReportTag;
 import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
+import com.kuit.findyou.global.common.exception.CustomException;
+import com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus;
 import com.kuit.findyou.global.external.client.KakaoCoordinateClient;
 import com.kuit.findyou.global.external.client.ProtectingAnimalApiClient;
 import com.kuit.findyou.global.external.dto.ProtectingAnimalItemDTO;
@@ -21,6 +23,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -46,6 +50,7 @@ public class ProtectingReportSyncServiceImpl implements ProtectingReportSyncServ
             logSyncResult(syncResult, startTime);
         } catch (Exception e) {
             log.error("[구조동물 데이터 동기화 실패]", e);
+            throw new CustomException(PROTECTING_REPORT_SYNC_FAILED);
         }
     }
 

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -42,6 +42,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     // 글 - Report
     REPORT_NOT_FOUND(404, "존재하지 않는 신고글입니다."),
     PROTECTING_REPORT_NOT_FOUND(404, "존재하지 않는 보호글입니다."),
+    PROTECTING_REPORT_SYNC_FAILED(500, "구조동물 데이터 동기화에 실패하였습니다."),
     MISSING_REPORT_NOT_FOUND(404, "존재하지 않는 실종 신고글입니다."),
     WITNESS_REPORT_NOT_FOUND(404, "존재하지 않는 목격 신고글입니다."),
     ILLEGAL_TAG(500, "잘못된 태그값입니다."),

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -42,7 +42,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     // 글 - Report
     REPORT_NOT_FOUND(404, "존재하지 않는 신고글입니다."),
     PROTECTING_REPORT_NOT_FOUND(404, "존재하지 않는 보호글입니다."),
-    PROTECTING_REPORT_SYNC_FAILED(500, "구조동물 데이터 동기화에 실패하였습니다."),
+    PROTECTING_REPORT_SYNC_FAILED(500, "구조 동물 데이터 동기화에 실패하였습니다."),
+    MISSING_REPORT_SYNC_FAILED(500, "분실 동물 데이터 동기화에 실패하였습니다."),
     MISSING_REPORT_NOT_FOUND(404, "존재하지 않는 실종 신고글입니다."),
     WITNESS_REPORT_NOT_FOUND(404, "존재하지 않는 목격 신고글입니다."),
     ILLEGAL_TAG(500, "잘못된 태그값입니다."),

--- a/src/main/java/com/kuit/findyou/global/external/client/MissingAnimalApiClient.java
+++ b/src/main/java/com/kuit/findyou/global/external/client/MissingAnimalApiClient.java
@@ -2,6 +2,7 @@ package com.kuit.findyou.global.external.client;
 
 import com.kuit.findyou.global.external.dto.MissingAnimalApiFullResponse;
 import com.kuit.findyou.global.external.dto.MissingAnimalItemDTO;
+import com.kuit.findyou.global.external.exception.MissingAnimalApiClientException;
 import com.kuit.findyou.global.external.properties.LossAnimalInfoProperties;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -10,6 +11,8 @@ import org.springframework.web.client.RestClient;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.kuit.findyou.global.external.constant.ExternalExceptionMessage.*;
 
 @Component
 @Slf4j
@@ -38,7 +41,7 @@ public class MissingAnimalApiClient {
 
                 if (isEmptyResponse(response)) {
                     log.warn("[분실동물 공공데이터 응답이 비어있습니다] pageNo={}", pageNo);
-                    break;
+                    throw new MissingAnimalApiClientException(MISSING_ANIMAL_API_CLIENT_EMPTY_RESPONSE);
                 }
 
                 List<MissingAnimalItemDTO> currentPageItems = response.response().body().items().item();
@@ -52,7 +55,7 @@ public class MissingAnimalApiClient {
 
             } catch (Exception e) {
                 log.error("[분실동물 공공데이터 페이지 {} 조회 실패]", pageNo, e);
-                break;
+                throw new MissingAnimalApiClientException(MISSING_ANIMAL_API_CLIENT_CALL_FAILED);
             }
         }
 

--- a/src/main/java/com/kuit/findyou/global/external/client/ProtectingAnimalApiClient.java
+++ b/src/main/java/com/kuit/findyou/global/external/client/ProtectingAnimalApiClient.java
@@ -1,8 +1,10 @@
 package com.kuit.findyou.global.external.client;
 
 import com.kuit.findyou.global.common.exception.CustomException;
+import com.kuit.findyou.global.external.constant.ExternalExceptionMessage;
 import com.kuit.findyou.global.external.dto.ProtectingAnimalApiFullResponse;
 import com.kuit.findyou.global.external.dto.ProtectingAnimalItemDTO;
+import com.kuit.findyou.global.external.exception.ProtectingAnimalApiClientException;
 import com.kuit.findyou.global.external.properties.ProtectingAnimalApiProperties;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -15,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.HOME_STATISTICS_UPDATE_FAILED;
+import static com.kuit.findyou.global.external.constant.ExternalExceptionMessage.*;
 
 @Component
 @Slf4j
@@ -44,7 +47,7 @@ public class ProtectingAnimalApiClient {
 
                 if (isEmptyResponse(response)) {
                     log.warn("[구조동물 공공데이터 응답이 비어있습니다] pageNo={}", pageNo);
-                    break;
+                    throw new ProtectingAnimalApiClientException(PROTECTING_ANIMAL_API_CLIENT_EMPTY_RESPONSE);
                 }
 
                 List<ProtectingAnimalItemDTO> currentPageItems = response.response().body().items().item();
@@ -58,7 +61,7 @@ public class ProtectingAnimalApiClient {
 
             } catch (Exception e) {
                 log.error("[구조동물 공공데이터 페이지 {} 조회 실패]", pageNo, e);
-                break;
+                throw new ProtectingAnimalApiClientException(PROTECTING_ANIMAL_API_CLIENT_CALL_FAILED);
             }
         }
 

--- a/src/main/java/com/kuit/findyou/global/external/constant/ExternalExceptionMessage.java
+++ b/src/main/java/com/kuit/findyou/global/external/constant/ExternalExceptionMessage.java
@@ -4,6 +4,9 @@ import lombok.Getter;
 
 @Getter
 public enum ExternalExceptionMessage {
+    PROTECTING_ANIMAL_API_CLIENT_EMPTY_RESPONSE("구조 동물 데이터 응답이 비어있습니다."),
+    PROTECTING_ANIMAL_API_CLIENT_CALL_FAILED("구조 동물 데이터 조회에 실패했습니다."),
+
     OPENAI_CLIENT_EMPTY_RESPONSE("OpenAI Vision API 응답이 비어있습니다."),
     OPENAI_CLIENT_CALL_FAILED("OpenAI Vision API 호출 중 오류가 발생했습니다."),
 

--- a/src/main/java/com/kuit/findyou/global/external/constant/ExternalExceptionMessage.java
+++ b/src/main/java/com/kuit/findyou/global/external/constant/ExternalExceptionMessage.java
@@ -7,6 +7,9 @@ public enum ExternalExceptionMessage {
     PROTECTING_ANIMAL_API_CLIENT_EMPTY_RESPONSE("구조 동물 데이터 응답이 비어있습니다."),
     PROTECTING_ANIMAL_API_CLIENT_CALL_FAILED("구조 동물 데이터 조회에 실패했습니다."),
 
+    MISSING_ANIMAL_API_CLIENT_EMPTY_RESPONSE("분실 동물 데이터 응답이 비어있습니다."),
+    MISSING_ANIMAL_API_CLIENT_CALL_FAILED("분실 동물 데이터 조회에 실패했습니다."),
+
     OPENAI_CLIENT_EMPTY_RESPONSE("OpenAI Vision API 응답이 비어있습니다."),
     OPENAI_CLIENT_CALL_FAILED("OpenAI Vision API 호출 중 오류가 발생했습니다."),
 

--- a/src/main/java/com/kuit/findyou/global/external/exception/MissingAnimalApiClientException.java
+++ b/src/main/java/com/kuit/findyou/global/external/exception/MissingAnimalApiClientException.java
@@ -1,0 +1,22 @@
+package com.kuit.findyou.global.external.exception;
+
+import com.kuit.findyou.global.external.constant.ExternalExceptionMessage;
+
+public class MissingAnimalApiClientException extends RuntimeException {
+
+    public MissingAnimalApiClientException(String message) {
+        super(message);
+    }
+
+    public MissingAnimalApiClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MissingAnimalApiClientException(ExternalExceptionMessage externalExceptionMessage) {
+        super(externalExceptionMessage.getValue());
+    }
+
+    public MissingAnimalApiClientException(ExternalExceptionMessage externalExceptionMessage, Throwable cause) {
+        super(externalExceptionMessage.getValue(), cause);
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/external/exception/ProtectingAnimalApiClientException.java
+++ b/src/main/java/com/kuit/findyou/global/external/exception/ProtectingAnimalApiClientException.java
@@ -1,0 +1,22 @@
+package com.kuit.findyou.global.external.exception;
+
+import com.kuit.findyou.global.external.constant.ExternalExceptionMessage;
+
+public class ProtectingAnimalApiClientException extends RuntimeException {
+
+    public ProtectingAnimalApiClientException(String message) {
+        super(message);
+    }
+
+    public ProtectingAnimalApiClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ProtectingAnimalApiClientException(ExternalExceptionMessage externalExceptionMessage) {
+        super(externalExceptionMessage.getValue());
+    }
+
+    public ProtectingAnimalApiClientException(ExternalExceptionMessage externalExceptionMessage, Throwable cause) {
+        super(externalExceptionMessage.getValue(), cause);
+    }
+}

--- a/src/test/java/com/kuit/findyou/global/external/client/MissingAnimalApiClientTest.java
+++ b/src/test/java/com/kuit/findyou/global/external/client/MissingAnimalApiClientTest.java
@@ -2,6 +2,7 @@ package com.kuit.findyou.global.external.client;
 
 import com.kuit.findyou.global.external.dto.MissingAnimalApiFullResponse;
 import com.kuit.findyou.global.external.dto.MissingAnimalItemDTO;
+import com.kuit.findyou.global.external.exception.MissingAnimalApiClientException;
 import com.kuit.findyou.global.external.properties.LossAnimalInfoProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,7 +19,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.function.Function;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -95,8 +96,8 @@ class MissingAnimalApiClientTest {
     }
 
     @Test
-    @DisplayName("빈 응답: items.item() == null → 즉시 종료, 빈 리스트 반환")
-    void fetchAll_emptyResponse_returnsEmptyList() {
+    @DisplayName("빈 응답: items.item() == null → 예외 발생(EMPTY_RESPONSE)")
+    void fetchAll_emptyResponse_throws() {
         stubChain();
 
         var empty = mock(MissingAnimalApiFullResponse.class, Answers.RETURNS_DEEP_STUBS);
@@ -104,73 +105,68 @@ class MissingAnimalApiClientTest {
 
         when(responseSpec.body(MissingAnimalApiFullResponse.class)).thenReturn(empty);
 
-        var result = client.fetchAllMissingAnimals("20240101", "20240131");
-
-        assertThat(result).isEmpty();
+        assertThatThrownBy(() -> client.fetchAllMissingAnimals("20240101", "20240131"))
+                .isInstanceOf(MissingAnimalApiClientException.class);
     }
 
     @Test
-    @DisplayName("중간 예외: 1페이지 수집 후 2페이지에서 예외 → 누적분만 반환")
-    void fetchAll_exceptionOnSecondPage_returnsAccumulated() {
+    @DisplayName("중간 예외: 1페이지 수집 후 2페이지에서 예외 → MissingAnimalApiClientException(CALL_FAILED)")
+    void fetchAll_exceptionOnSecondPage_throws() {
         stubChain();
 
         var i1 = mock(MissingAnimalItemDTO.class);
         var page1 = deepResponse(List.of(i1), "2000"); // totalPages=2
 
         when(responseSpec.body(MissingAnimalApiFullResponse.class))
-                .thenReturn(page1)                          // 1페이지 OK
-                .thenThrow(new RuntimeException("timeout")); // 2페이지에서 예외
+                .thenReturn(page1)                         // 1페이지 OK
+                .thenThrow(new RuntimeException("timeout"));// 2페이지에서 예외
 
-        var result = client.fetchAllMissingAnimals("20240101", "20240131");
-
-        assertThat(result).containsExactly(i1);
+        assertThatThrownBy(() -> client.fetchAllMissingAnimals("20240101", "20240131"))
+                .isInstanceOf(MissingAnimalApiClientException.class);
     }
 
     @Test
-    @DisplayName("빈 응답: body()가 아예 null → 즉시 종료, 빈 리스트")
-    void fetchAll_responseNull_returnsEmpty() {
+    @DisplayName("빈 응답: body()가 아예 null → 예외 발생(EMPTY_RESPONSE)")
+    void fetchAll_responseNull_throws() {
         stubChain();
-        MissingAnimalApiFullResponse full =
-                mock(MissingAnimalApiFullResponse.class, Answers.RETURNS_DEEP_STUBS);
-        // 최상위 response()가 null
+        var full = mock(MissingAnimalApiFullResponse.class, Answers.RETURNS_DEEP_STUBS);
         when(full.response()).thenReturn(null);
 
         when(responseSpec.body(MissingAnimalApiFullResponse.class)).thenReturn(full);
 
-        var result = client.fetchAllMissingAnimals("20240101", "20240131");
-        assertThat(result).isEmpty();
+        assertThatThrownBy(() -> client.fetchAllMissingAnimals("20240101", "20240131"))
+                .isInstanceOf(MissingAnimalApiClientException.class);
     }
 
     @Test
-    @DisplayName("빈 응답: responseSpec.body(...) 자체가 null → 즉시 종료, 빈 리스트")
-    void fetchAll_bodyCallReturnsNull_returnsEmpty() {
+    @DisplayName("빈 응답: responseSpec.body(...) 자체가 null → 예외 발생(EMPTY_RESPONSE)")
+    void fetchAll_bodyCallReturnsNull_throws() {
         stubChain();
         when(responseSpec.body(MissingAnimalApiFullResponse.class)).thenReturn(null);
 
-        var result = client.fetchAllMissingAnimals("20240101", "20240131");
-        assertThat(result).isEmpty();
+        assertThatThrownBy(() -> client.fetchAllMissingAnimals("20240101", "20240131"))
+                .isInstanceOf(MissingAnimalApiClientException.class);
     }
 
     @Test
-    @DisplayName("빈 응답: items()가 null → 즉시 종료, 빈 리스트")
-    void fetchAll_itemsNull_returnsEmpty() {
+    @DisplayName("빈 응답: items()가 null → 예외 발생(EMPTY_RESPONSE)")
+    void fetchAll_itemsNull_throws() {
         stubChain();
-        MissingAnimalApiFullResponse full =
-                mock(MissingAnimalApiFullResponse.class, Answers.RETURNS_DEEP_STUBS);
+        var full = mock(MissingAnimalApiFullResponse.class, Answers.RETURNS_DEEP_STUBS);
         when(full.response().body().items()).thenReturn(null);
 
         when(responseSpec.body(MissingAnimalApiFullResponse.class)).thenReturn(full);
 
-        var result = client.fetchAllMissingAnimals("20240101", "20240131");
-        assertThat(result).isEmpty();
+        assertThatThrownBy(() -> client.fetchAllMissingAnimals("20240101", "20240131"))
+                .isInstanceOf(MissingAnimalApiClientException.class);
     }
 
     @Test
-    @DisplayName("경계값: totalCount=0, items 빈 리스트 → 수집 없이 종료(while은 정상 경유)")
-    void fetchAll_totalCountZero_returnsEmptyButPassesLoop() {
+    @DisplayName("경계값: totalCount=0, items 빈 리스트 → 예외 없이 빈 리스트 반환")
+    void fetchAll_totalCountZero_returnsEmpty() {
         stubChain();
-        // items 빈 리스트 + totalCount=0 → isEmptyResponse=false, addAll(0), 마지막 페이지 즉시 종료
-        var page1 = deepResponse(List.of(), "0");
+        var page1 = deepResponse(List.of(), "0"); // 구조는 정상, 데이터만 없음
+
         when(responseSpec.body(MissingAnimalApiFullResponse.class)).thenReturn(page1);
 
         var result = client.fetchAllMissingAnimals("20240101", "20240131");
@@ -182,12 +178,11 @@ class MissingAnimalApiClientTest {
     void fetchAll_totalCountExactPageSize_onePage() {
         stubChain();
         var i1 = mock(MissingAnimalItemDTO.class);
-        var page1 = deepResponse(List.of(i1), "1000"); // 페이지사이즈=1000 → totalPages=1
+        var page1 = deepResponse(List.of(i1), "1000");
 
         when(responseSpec.body(MissingAnimalApiFullResponse.class)).thenReturn(page1);
 
         var result = client.fetchAllMissingAnimals("20240101", "20240131");
         assertThat(result).containsExactly(i1);
     }
-
 }

--- a/src/test/java/com/kuit/findyou/global/external/client/ProtectingAnimalApiClientTest.java
+++ b/src/test/java/com/kuit/findyou/global/external/client/ProtectingAnimalApiClientTest.java
@@ -2,6 +2,7 @@ package com.kuit.findyou.global.external.client;
 
 import com.kuit.findyou.global.external.dto.ProtectingAnimalApiFullResponse;
 import com.kuit.findyou.global.external.dto.ProtectingAnimalItemDTO;
+import com.kuit.findyou.global.external.exception.ProtectingAnimalApiClientException;
 import com.kuit.findyou.global.external.properties.ProtectingAnimalApiProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -95,8 +97,8 @@ class ProtectingAnimalApiClientTest {
     }
 
     @Test
-    @DisplayName("빈 응답: items.item() == null → 즉시 종료, 빈 리스트 반환")
-    void fetchAll_emptyResponse_returnsEmptyList() {
+    @DisplayName("빈 응답: items.item() == null → 예외 발생(EMPTY_RESPONSE)")
+    void fetchAll_emptyResponse_throws() {
         stubChain();
 
         var empty = mock(ProtectingAnimalApiFullResponse.class, Answers.RETURNS_DEEP_STUBS);
@@ -104,62 +106,60 @@ class ProtectingAnimalApiClientTest {
 
         when(responseSpec.body(ProtectingAnimalApiFullResponse.class)).thenReturn(empty);
 
-        var result = client.fetchAllProtectingAnimals();
-
-        assertThat(result).isEmpty();
+        assertThatThrownBy(() -> client.fetchAllProtectingAnimals())
+                .isInstanceOf(ProtectingAnimalApiClientException.class);
     }
 
     @Test
-    @DisplayName("중간 예외: 1페이지 수집 후 2페이지에서 예외 → 누적분만 반환")
-    void fetchAll_exceptionOnSecondPage_returnsAccumulated() {
+    @DisplayName("중간 예외: 1페이지 수집 후 2페이지에서 예외 → ProtectingAnimalApiClientException(CALL_FAILED)")
+    void fetchAll_exceptionOnSecondPage_throws() {
         stubChain();
 
         var i1 = mock(ProtectingAnimalItemDTO.class);
         var page1 = deepResponse(List.of(i1), "2000"); // totalPages=2
 
         when(responseSpec.body(ProtectingAnimalApiFullResponse.class))
-                .thenReturn(page1)                         // 1페이지 OK
-                .thenThrow(new RuntimeException("timeout")); // 2페이지 예외
+                .thenReturn(page1)                          // 1페이지 OK
+                .thenThrow(new RuntimeException("timeout"));// 2페이지 예외
 
-        var result = client.fetchAllProtectingAnimals();
-
-        assertThat(result).containsExactly(i1);
+        assertThatThrownBy(() -> client.fetchAllProtectingAnimals())
+                .isInstanceOf(ProtectingAnimalApiClientException.class);
     }
 
     @Test
-    @DisplayName("빈 응답: response()가 null → 즉시 종료, 빈 리스트")
-    void fetchAll_responseNull_returnsEmpty() {
+    @DisplayName("빈 응답: response()가 null → 예외 발생(EMPTY_RESPONSE)")
+    void fetchAll_responseNull_throws() {
         stubChain();
         var full = mock(ProtectingAnimalApiFullResponse.class, Answers.RETURNS_DEEP_STUBS);
         when(full.response()).thenReturn(null);
 
         when(responseSpec.body(ProtectingAnimalApiFullResponse.class)).thenReturn(full);
 
-        var result = client.fetchAllProtectingAnimals();
-        assertThat(result).isEmpty();
+        assertThatThrownBy(() -> client.fetchAllProtectingAnimals())
+                .isInstanceOf(ProtectingAnimalApiClientException.class);
     }
 
     @Test
-    @DisplayName("빈 응답: responseSpec.body(...) 자체가 null → 즉시 종료, 빈 리스트")
-    void fetchAll_bodyCallReturnsNull_returnsEmpty() {
+    @DisplayName("빈 응답: responseSpec.body(...) 자체가 null → 예외 발생(EMPTY_RESPONSE)")
+    void fetchAll_bodyCallReturnsNull_throws() {
         stubChain();
         when(responseSpec.body(ProtectingAnimalApiFullResponse.class)).thenReturn(null);
 
-        var result = client.fetchAllProtectingAnimals();
-        assertThat(result).isEmpty();
+        assertThatThrownBy(() -> client.fetchAllProtectingAnimals())
+                .isInstanceOf(ProtectingAnimalApiClientException.class);
     }
 
     @Test
-    @DisplayName("빈 응답: items()가 null → 즉시 종료, 빈 리스트")
-    void fetchAll_itemsNull_returnsEmpty() {
+    @DisplayName("빈 응답: items()가 null → 예외 발생(EMPTY_RESPONSE)")
+    void fetchAll_itemsNull_throws() {
         stubChain();
         var full = mock(ProtectingAnimalApiFullResponse.class, Answers.RETURNS_DEEP_STUBS);
         when(full.response().body().items()).thenReturn(null);
 
         when(responseSpec.body(ProtectingAnimalApiFullResponse.class)).thenReturn(full);
 
-        var result = client.fetchAllProtectingAnimals();
-        assertThat(result).isEmpty();
+        assertThatThrownBy(() -> client.fetchAllProtectingAnimals())
+                .isInstanceOf(ProtectingAnimalApiClientException.class);
     }
 
     @Test


### PR DESCRIPTION
## Related issue 🛠
- closed #121 

## Work Description 📝
- 공공데이터 장애가 발생한 경우를 대비할 수 있도록 코드를 수정하였습니다.

기존에는 공공데이터로부터 응답이 오지 않거나, 공공데이터 자체에 문제가 있다고 판단되더라도 에러를 터뜨리지 않고 넘어가도록 구현하였었습니다.
다만 현재 실제로 공공데이터포털에 장애가 생겨서 API 요청에 에러가 발생하는 상황인데, 그러다보니 저희 서비스에 구현되어있는 구조 동물 데이터 동기화 로직에서 문제가 발생하였습니다.

기존 구조 동물 데이터 동기화 로직은

- 공공데이터에서 새롭게 응답받은 데이터 && 우리 DB에 없는 데이터 => 새롭게 DB에 저장
-우리 DB에 존재하는 데이터 && 공공데이터에서 응답에 포함하지 않는 데이터 => 더이상 관리되지 않는 데이터라고 판단하고 우리 DB에서 삭제

이런 형식으로 구현이 되어있었는데, 현재 공공데이터에서 장애가 발생하다보니 공공데이터에서 아무런 데이터도 반환해주지 못하는 상황이 발생했습니다.
그러다보니 기존에 저희 DB에 수천건 이상의 구조동물 데이터가 저장되어있었으나, 공공데이터에서는 아무런 데이터도 반환하지 않다보니, 저희 DB에 존재하는 수천건의 데이터가 더이상 관리할 필요가 없는 데이터라고 판단되어서 싹 다 삭제되어버리는 문제가 발생했습니다.

따라서 공공데이터 자체에서 에러가 발생한다거나, 아무런 데이터도 반환하지 않는 케이스는 에러라고 판단하고 동기화를 중단하도록 변경하였습니다.

## Screenshot 📸

## Uncompleted Tasks 😅

## To Reviewers 📢
