### PR TITLE
[HotFix] 공공데이터 API로 홈화면 통계를 합산하는 로직 수정

### DIFF
--- a/src/main/java/com/kuit/findyou/global/external/dto/RescueAnimalStatsServiceApiResponse.java
+++ b/src/main/java/com/kuit/findyou/global/external/dto/RescueAnimalStatsServiceApiResponse.java
@@ -1,16 +1,20 @@
 package com.kuit.findyou.global.external.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record RescueAnimalStatsServiceApiResponse(
         Response response
 ) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public record Response(
             Body body
     ){ }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public record Body(
             Items items
     ) { }


### PR DESCRIPTION
## Related issue 🛠
- closed #133

## Work Description 📝
- 공공데이터 API의 응답이 불안정해서 예외처리를 다음과 같이 변경했습니다.

1. 응답 역직렬화 과정에서 예외를 처리할 수 있도록 수정
2. 응답에 필수 파라미터가 누락된 경우 이를 기본 값으로 대체하도록 수정
3. 응답에서 파싱하지 않는 필드를 무시하도록 설정

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 동물 구조 통계 API 응답 처리의 안정성 개선
  * 누락된 데이터에 대한 기본값 처리 로직 추가
  * API 응답 검증 강화로 비정상 응답 처리 개선

* **Refactor**
  * 예외 처리 로직 최적화 및 에러 로깅 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->