### PR TITLE
[Hotfix] 홈화면 통계 파싱에서 타임아웃을 변경

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/home/service/stats/HomeStatisticsServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/home/service/stats/HomeStatisticsServiceImpl.java
@@ -8,6 +8,7 @@ import com.kuit.findyou.global.external.client.LossAnimalApiClient;
 import com.kuit.findyou.global.external.client.ProtectingAnimalApiClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -22,7 +23,8 @@ import java.util.concurrent.TimeUnit;
 @Service
 @RequiredArgsConstructor
 public class HomeStatisticsServiceImpl implements HomeStatisticsService{
-    private long CALL_TIMEOUT_SEC = 5;
+    @Value("${findyou.home-stats.parsing-timeout-sec}")
+    private long PARSING_TIMEOUT_SEC;
     private final AnimalStatsApiClient animalStatsApiClient;
     private final ProtectingAnimalApiClient protectingAnimalApiClient;
     private final LossAnimalApiClient lossAnimalApiClient;
@@ -90,15 +92,15 @@ public class HomeStatisticsServiceImpl implements HomeStatisticsService{
 
         CompletableFuture<ProtectingAndAdoptedAnimalCount> pna =
                 CompletableFuture.supplyAsync(() -> animalStatsApiClient.fetchProtectingAndAdoptedAnimalCount(bgnde, endde), statisticsExecutor)
-                        .orTimeout(CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
+                        .orTimeout(PARSING_TIMEOUT_SEC, TimeUnit.SECONDS);
 
         CompletableFuture<String> rescued =
                 CompletableFuture.supplyAsync(() -> protectingAnimalApiClient.fetchRescuedAnimalCount(bgnde, endde), statisticsExecutor)
-                        .orTimeout(CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
+                        .orTimeout(PARSING_TIMEOUT_SEC, TimeUnit.SECONDS);
 
         CompletableFuture<String> reported =
                 CompletableFuture.supplyAsync(() -> lossAnimalApiClient.fetchReportedAnimalCount(bgnde, endde), statisticsExecutor)
-                        .orTimeout(CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
+                        .orTimeout(PARSING_TIMEOUT_SEC, TimeUnit.SECONDS);
 
         return CompletableFuture.allOf(pna, rescued, reported)
                 .thenApply(v -> {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -156,6 +156,8 @@ findyou:
     access:
       expire-ms: ${JWT_ACCESS_EXPIRE_MS}
     secret-key : ${JWT_SECRET_KEY}
+  home-stats:
+    parsing-timeout-sec: ${HOME_STATS_PARSING_TIMEOUT_SEC}
 
 cloud:
   aws:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -31,6 +31,8 @@ findyou:
     access:
       expire-ms: 6000000
     secret-key : secretkey1224secretkey1224secretkey1224secretkey1224
+  home-stats:
+    parsing-timeout-sec: 20
 
 cloud:
   aws:


### PR DESCRIPTION
## Related issue 🛠
- closed #141

## Work Description 📝
- 홈화면 통계 파싱 로직에서 파싱에 실패하는 발생하는 문제가 있었습니다. CompletableFuture에서 파싱하는 시간이 기존 타임아웃보다 오래 걸려서 파싱에 실패했던 것입니다. 로컬에서는 타임아웃을 10초로 변경하니 파싱에 성공했습니다. 타임아웃을 보수적으로 30초로 설정하면 파싱에 실패하진 않을 것으로 보입니다. 그런데 추후에 타임아웃 시간 변경에 대비해서 타임아웃 설정 방식을 환경변수 주입으로 변경했습니다.
- approve해주시면 개발서버와 배포서버의 환경변수에 `HOME_STATS_PARSING_TIMEOUT_SEC`를 추가해두겠습니다

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- 없습니다

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 홈 통계 파싱 타임아웃을 환경 변수로 설정 가능하도록 변경했습니다. 이제 `HOME_STATS_PARSING_TIMEOUT_SEC` 환경 변수를 통해 타임아웃 값을 유연하게 조정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->