### PR TITLE
[Feat] 스케줄링을 위한, S3 URL을 반환하는 보호글 랜덤 조회 기능 구현

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-IS_BLUE_RUNNING=$(docker ps | grep findyou_blue)
+if docker ps | grep -q findyou_blue; then
+  IS_BLUE_RUNNING=true
+else
+  IS_BLUE_RUNNING=false
+fi
 export NGINX_CONF="/etc/nginx/sites-available/default"
 
 # blue 가 실행 중이면 green 을 up

--- a/src/main/java/com/kuit/findyou/domain/home/service/stats/HomeStatisticsServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/home/service/stats/HomeStatisticsServiceImpl.java
@@ -8,6 +8,7 @@ import com.kuit.findyou.global.external.client.LossAnimalApiClient;
 import com.kuit.findyou.global.external.client.ProtectingAnimalApiClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -22,7 +23,8 @@ import java.util.concurrent.TimeUnit;
 @Service
 @RequiredArgsConstructor
 public class HomeStatisticsServiceImpl implements HomeStatisticsService{
-    private long CALL_TIMEOUT_SEC = 5;
+    @Value("${findyou.home-stats.parsing-timeout-sec}")
+    private long PARSING_TIMEOUT_SEC;
     private final AnimalStatsApiClient animalStatsApiClient;
     private final ProtectingAnimalApiClient protectingAnimalApiClient;
     private final LossAnimalApiClient lossAnimalApiClient;
@@ -90,15 +92,15 @@ public class HomeStatisticsServiceImpl implements HomeStatisticsService{
 
         CompletableFuture<ProtectingAndAdoptedAnimalCount> pna =
                 CompletableFuture.supplyAsync(() -> animalStatsApiClient.fetchProtectingAndAdoptedAnimalCount(bgnde, endde), statisticsExecutor)
-                        .orTimeout(CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
+                        .orTimeout(PARSING_TIMEOUT_SEC, TimeUnit.SECONDS);
 
         CompletableFuture<String> rescued =
                 CompletableFuture.supplyAsync(() -> protectingAnimalApiClient.fetchRescuedAnimalCount(bgnde, endde), statisticsExecutor)
-                        .orTimeout(CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
+                        .orTimeout(PARSING_TIMEOUT_SEC, TimeUnit.SECONDS);
 
         CompletableFuture<String> reported =
                 CompletableFuture.supplyAsync(() -> lossAnimalApiClient.fetchReportedAnimalCount(bgnde, endde), statisticsExecutor)
-                        .orTimeout(CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
+                        .orTimeout(PARSING_TIMEOUT_SEC, TimeUnit.SECONDS);
 
         return CompletableFuture.allOf(pna, rescued, reported)
                 .thenApply(v -> {

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -9,6 +9,7 @@ import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailRespons
 import com.kuit.findyou.domain.report.dto.response.WitnessReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.model.*;
 import com.kuit.findyou.domain.report.service.facade.ReportServiceFacade;
+import com.kuit.findyou.domain.report.service.retrieve.ProtectingReportRetrieveWithS3Service;
 import com.kuit.findyou.global.common.annotation.CustomExceptionDescription;
 import com.kuit.findyou.global.common.response.BaseResponse;
 import com.kuit.findyou.global.jwt.annotation.LoginUserId;
@@ -21,6 +22,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.*;
 
 @RestController
@@ -31,6 +34,7 @@ import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.
 public class ReportController {
 
     private final ReportServiceFacade reportServiceFacade;
+    private final ProtectingReportRetrieveWithS3Service protectingReportRetrieveWithS3Service;
 
     @Operation(summary = "보호글 상세 조회 API", description = "보호글의 정보를 상세 조회하기 위한 API")
     @GetMapping("/protecting-reports/{reportId}")
@@ -106,6 +110,18 @@ public class ReportController {
     ) {
         reportServiceFacade.deleteReport(reportId, userId);
         return BaseResponse.ok(null);
+    }
+
+    @Operation(summary = "보호글 S3 이미지 포함 랜덤 조회 API", description = "랜덤으로 보호글을 선택하여 원본 이미지를 S3에 업로드 후, S3 URL 포함 보호글을 리스트로 반환합니다.")
+    @GetMapping("/protecting-reports/random-s3")
+    @CustomExceptionDescription(DEFAULT)
+    public BaseResponse<List<ProtectingReportDetailResponseDTO>> getRandomProtectingReportsWithS3(
+            @RequestParam(name = "count", defaultValue = "1") int count
+    ) {
+        List<ProtectingReportDetailResponseDTO> details =
+                protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(count);
+
+        return BaseResponse.ok(details);
     }
 
 }

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -17,9 +17,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -31,6 +34,7 @@ import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.
 @RequestMapping("/api/v2/reports")
 @Tag(name = "Report", description = "글 관련 API")
 @RequiredArgsConstructor
+@Validated
 public class ReportController {
 
     private final ReportServiceFacade reportServiceFacade;
@@ -116,7 +120,8 @@ public class ReportController {
     @GetMapping("/protecting-reports/random-s3")
     @CustomExceptionDescription(DEFAULT)
     public BaseResponse<List<ProtectingReportDetailResponseDTO>> getRandomProtectingReportsWithS3(
-            @RequestParam(name = "count", defaultValue = "1") int count
+            @RequestParam(name = "count", defaultValue = "1")
+             @Min(1) @Max(10) int count
     ) {
         List<ProtectingReportDetailResponseDTO> details =
                 protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(count);

--- a/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
@@ -1,10 +1,10 @@
 package com.kuit.findyou.domain.report.repository;
 
 import com.kuit.findyou.domain.report.model.ProtectingReport;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -19,7 +19,7 @@ public interface ProtectingReportRepository extends JpaRepository<ProtectingRepo
 
     List<ProtectingReport> findByNoticeNumberIn(Set<String> noticeNumbers);
 
-    @Query(value = "SELECT * FROM protecting_reports ORDER BY RAND() LIMIT :limit", nativeQuery = true)
-    List<ProtectingReport> findRandomReports(@Param("limit") int limit);
+    @Query("SELECT p FROM ProtectingReport p ORDER BY function('RAND')")
+    List<ProtectingReport> findRandomReports(Pageable pageable);
 }
 

--- a/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
@@ -3,6 +3,8 @@ package com.kuit.findyou.domain.report.repository;
 import com.kuit.findyou.domain.report.model.ProtectingReport;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,5 +18,8 @@ public interface ProtectingReportRepository extends JpaRepository<ProtectingRepo
     Optional<ProtectingReport> findWithImagesById(Long id);
 
     List<ProtectingReport> findByNoticeNumberIn(Set<String> noticeNumbers);
+
+    @Query(value = "SELECT * FROM protecting_reports ORDER BY RAND() LIMIT :limit", nativeQuery = true)
+    List<ProtectingReport> findRandomReports(@Param("limit") int limit);
 }
 

--- a/src/main/java/com/kuit/findyou/domain/report/service/detail/strategy/ProtectingReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/detail/strategy/ProtectingReportDetailStrategy.java
@@ -2,14 +2,13 @@ package com.kuit.findyou.domain.report.service.detail.strategy;
 
 import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.model.ProtectingReport;
-import com.kuit.findyou.domain.report.model.Report;
 import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
 import com.kuit.findyou.domain.report.util.ReportFormatUtil;
 import com.kuit.findyou.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.math.BigDecimal;
+import java.util.List;
 
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.PROTECTING_REPORT_NOT_FOUND;
 
@@ -21,9 +20,17 @@ public class ProtectingReportDetailStrategy implements ReportDetailStrategy<Prot
 
     @Override
     public ProtectingReportDetailResponseDTO getDetail(ProtectingReport report, boolean interest) {
+        return toDetailDto(report, report.getReportImagesUrlList(), interest);
+    }
 
+    // 공통 매핑 메서드
+    public ProtectingReportDetailResponseDTO toDetailDto(
+            ProtectingReport report,
+            List<String> imageUrls,
+            boolean interest
+    ) {
         return new ProtectingReportDetailResponseDTO(
-                report.getReportImagesUrlList(),
+                imageUrls,
                 ReportFormatUtil.safeValue(report.getBreed()),
                 report.getTag().getValue(),
                 ReportFormatUtil.formatAge(report.getAge()),
@@ -45,7 +52,6 @@ public class ProtectingReportDetailStrategy implements ReportDetailStrategy<Prot
                 interest
         );
     }
-
 
     @Override
     public ProtectingReport getReport(Long reportId) {

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3Service.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3Service.java
@@ -1,0 +1,9 @@
+package com.kuit.findyou.domain.report.service.retrieve;
+
+import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailResponseDTO;
+
+import java.util.List;
+
+public interface ProtectingReportRetrieveWithS3Service {
+    List<ProtectingReportDetailResponseDTO> getRandomProtectingReportsWithS3(int count);
+}

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
@@ -37,7 +37,7 @@ public class ProtectingReportRetrieveWithS3ServiceImpl implements ProtectingRepo
     public List<ProtectingReportDetailResponseDTO> getRandomProtectingReportsWithS3(int count) {
 
         // 전체 보호글 조회
-        List<ProtectingReport> all = protectingReportRepository.findAll();
+        List<ProtectingReport> all = new ArrayList<>(protectingReportRepository.findAll());
         if (all.isEmpty()) {
             throw new CustomException(PROTECTING_REPORT_NOT_FOUND);
         }

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
@@ -10,12 +10,12 @@ import com.kuit.findyou.global.infrastructure.FileUploadingFailedException;
 import com.kuit.findyou.global.infrastructure.ImageUploader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -30,16 +30,16 @@ public class ProtectingReportRetrieveWithS3ServiceImpl implements ProtectingRepo
     private final ProtectingReportDetailStrategy protectingReportDetailStrategy;
 
     //외부 URL에서 이미지를 받아오기 위한 HTTP 클라이언트
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
 
     @Override
     @Transactional(readOnly = true)
     public List<ProtectingReportDetailResponseDTO> getRandomProtectingReportsWithS3(int count) {
 
-        int safeCount = (count <=0 ) ? 1 : count;
+        int limit = Math.max(1, count);
 
         //랜덤으로 count 만큼 조회
-        List<ProtectingReport> reports = new ArrayList<>(protectingReportRepository.findRandomReports(safeCount));
+        List<ProtectingReport> reports = protectingReportRepository.findRandomReports(PageRequest.of(0, limit));
         if(reports.isEmpty()) {
             throw new CustomException(PROTECTING_REPORT_NOT_FOUND);
         }

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
@@ -1,0 +1,92 @@
+package com.kuit.findyou.domain.report.service.retrieve;
+
+import com.kuit.findyou.domain.image.model.ReportImage;
+import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailResponseDTO;
+import com.kuit.findyou.domain.report.model.ProtectingReport;
+import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
+import com.kuit.findyou.domain.report.service.detail.strategy.ProtectingReportDetailStrategy;
+import com.kuit.findyou.global.common.exception.CustomException;
+import com.kuit.findyou.global.infrastructure.FileUploadingFailedException;
+import com.kuit.findyou.global.infrastructure.ImageUploader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.PROTECTING_REPORT_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class ProtectingReportRetrieveWithS3ServiceImpl implements ProtectingReportRetrieveWithS3Service{
+    private final ProtectingReportRepository protectingReportRepository;
+    private final ImageUploader imageUploader;
+    private final ProtectingReportDetailStrategy protectingReportDetailStrategy;
+
+    //외부 URL에서 이미지를 받아오기 위한 HTTP 클라이언트
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ProtectingReportDetailResponseDTO> getRandomProtectingReportsWithS3(int count) {
+
+        // 전체 보호글 조회
+        List<ProtectingReport> all = protectingReportRepository.findAll();
+        if (all.isEmpty()) {
+            throw new CustomException(PROTECTING_REPORT_NOT_FOUND);
+        }
+
+        //랜덤하게 섞고, 실제 사용할 개수 결정 (오류로 인해 전체 개수가 count보다 적은 경우를 대비)
+        Collections.shuffle(all);
+        int targetCount = Math.min(count, all.size());
+
+        List<ProtectingReportDetailResponseDTO> result = new ArrayList<>();
+
+        //앞에서부터 해당 개수만큼 선택
+        for (int i = 0; i < targetCount; i++) {
+            ProtectingReport report = all.get(i);
+
+            //보호글에 연결된 원본 이미지 가져오기
+            List<ReportImage> reportImages = report.getReportImages();
+            List<String> originalUrls = reportImages.stream()
+                    .map(ReportImage::getImageUrl)
+                    .toList();
+
+            //S3에 업로드허기
+            List<String> s3Urls = new ArrayList<>();
+            for (String url : originalUrls) {
+                try {
+                    byte[] imageBytes = restTemplate.getForObject(url, byte[].class);
+                    if (imageBytes == null || imageBytes.length == 0) {
+                        log.warn("[ProtectingReportS3] 빈 이미지 응답: url={}", url);
+                        continue;
+                    }
+
+                    String key = "protecting/" + report.getId() + "/" + UUID.randomUUID() + ".jpg";
+                    String s3Url = imageUploader.upload(imageBytes, key, "image/jpeg"); // 너네 S3 업로더 방식대로
+                    s3Urls.add(s3Url);
+
+                } catch (FileUploadingFailedException e) {
+                    //S3 자체 장애, 권한 등의 문제 발생 시
+                    log.error("[ProtectingReportS3] S3 업로드 실패 - reportId={}, url={}, message={}",
+                            report.getId(), url, e.getMessage(), e);
+                } catch (Exception e) {
+                    log.error("[ProtectingReportS3] 이미지 처리 중 예기치 못한 오류 발생 - reportId={}, url={}",
+                            report.getId(), url, e);
+                }
+            }
+
+            ProtectingReportDetailResponseDTO dto =
+                    protectingReportDetailStrategy.toDetailDto(report, s3Urls, false);
+
+            result.add(dto);
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
@@ -36,21 +36,17 @@ public class ProtectingReportRetrieveWithS3ServiceImpl implements ProtectingRepo
     @Transactional(readOnly = true)
     public List<ProtectingReportDetailResponseDTO> getRandomProtectingReportsWithS3(int count) {
 
-        // 전체 보호글 조회
-        List<ProtectingReport> all = new ArrayList<>(protectingReportRepository.findAll());
-        if (all.isEmpty()) {
+        int safeCount = (count <=0 ) ? 1 : count;
+
+        //랜덤으로 count 만큼 조회
+        List<ProtectingReport> reports = new ArrayList<>(protectingReportRepository.findRandomReports(safeCount));
+        if(reports.isEmpty()) {
             throw new CustomException(PROTECTING_REPORT_NOT_FOUND);
         }
 
-        //랜덤하게 섞고, 실제 사용할 개수 결정 (오류로 인해 전체 개수가 count보다 적은 경우를 대비)
-        Collections.shuffle(all);
-        int targetCount = Math.min(count, all.size());
-
         List<ProtectingReportDetailResponseDTO> result = new ArrayList<>();
 
-        //앞에서부터 해당 개수만큼 선택
-        for (int i = 0; i < targetCount; i++) {
-            ProtectingReport report = all.get(i);
+        for(ProtectingReport report : reports) {
 
             //보호글에 연결된 원본 이미지 가져오기
             List<ReportImage> reportImages = report.getReportImages();

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -49,6 +49,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     ILLEGAL_TAG(500, "잘못된 태그값입니다."),
     IMAGE_UPLOAD_HTTPS_REQUIRED(500, "이미지 URL은 https만 허용됩니다."),
     MISMATCH_REPORT_USER(404, "글 작성자와 삭제 요청자가 동일하지 않습니다."),
+    INVALID_REPORT_SAMPLE_COUNT(400, "유효하지 않은 count입니다."),
 
 
     // 글 이미지 - ReportImage

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -49,7 +49,6 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     ILLEGAL_TAG(500, "잘못된 태그값입니다."),
     IMAGE_UPLOAD_HTTPS_REQUIRED(500, "이미지 URL은 https만 허용됩니다."),
     MISMATCH_REPORT_USER(404, "글 작성자와 삭제 요청자가 동일하지 않습니다."),
-    INVALID_REPORT_SAMPLE_COUNT(400, "유효하지 않은 count입니다."),
 
 
     // 글 이미지 - ReportImage

--- a/src/main/java/com/kuit/findyou/global/config/WebConfig.java
+++ b/src/main/java/com/kuit/findyou/global/config/WebConfig.java
@@ -3,7 +3,9 @@ package com.kuit.findyou.global.config;
 import com.kuit.findyou.global.jwt.argument_resolver.LoginUserIdArgumentResolver;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -16,5 +18,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new LoginUserIdArgumentResolver(jwtUtil));
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/com/kuit/findyou/global/infrastructure/ImageUploader.java
+++ b/src/main/java/com/kuit/findyou/global/infrastructure/ImageUploader.java
@@ -4,5 +4,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface ImageUploader {
     String upload(MultipartFile file) throws FileUploadingFailedException;
+    String upload(byte[] content, String originalFileName, String contentType) throws FileUploadingFailedException;
     void delete(String s3ObjectKey);
 }

--- a/src/main/java/com/kuit/findyou/global/infrastructure/S3ImageUploader.java
+++ b/src/main/java/com/kuit/findyou/global/infrastructure/S3ImageUploader.java
@@ -59,6 +59,36 @@ public class S3ImageUploader implements ImageUploader {
     }
 
     @Override
+    public String upload(byte[] content, String originalFileName, String contentType) throws FileUploadingFailedException {
+
+            if (content == null || content.length == 0) {
+                throw new IllegalArgumentException("업로드할 파일이 비어 있을 수 없습니다");
+            }
+
+            String safeOriginalName = (originalFileName == null || originalFileName.isBlank())
+                    ? "image"
+                    : originalFileName;
+
+            String datePath = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+            String fileName = datePath + "/" + UUID.randomUUID() + "_" + safeOriginalName;
+
+            try {
+                PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(fileName)
+                        .contentType(contentType != null ? contentType : "image/jpeg")
+                        .build();
+
+                s3Client.putObject(putObjectRequest, RequestBody.fromBytes(content));
+
+                return getFileUrl(fileName);
+
+            } catch (S3Exception e) {
+                throw new FileUploadingFailedException("S3 업로드 실패: " + e.awsErrorDetails().errorMessage());
+            }
+    }
+
+    @Override
     public void delete(String s3ObjectKey) {
         if (s3ObjectKey == null || s3ObjectKey.isBlank()) {
             throw new IllegalArgumentException("S3에서 삭제할 객체 키가 없습니다.");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
       local : local-db, dev-port, common
       dev: dev-db, dev-port, common
       prod: prod-db, prod-port, common
-    active: dev
+    active: prod
   web:
     resources:
       add-mappings: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -156,6 +156,8 @@ findyou:
     access:
       expire-ms: ${JWT_ACCESS_EXPIRE_MS}
     secret-key : ${JWT_SECRET_KEY}
+  home-stats:
+    parsing-timeout-sec: ${HOME_STATS_PARSING_TIMEOUT_SEC}
 
 cloud:
   aws:

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -1,10 +1,15 @@
 package com.kuit.findyou.domain.report.controller;
 
+import com.kuit.findyou.domain.image.model.ReportImage;
+import com.kuit.findyou.domain.image.repository.ReportImageRepository;
 import com.kuit.findyou.domain.report.dto.request.CreateMissingReportRequest;
 import com.kuit.findyou.domain.report.dto.request.CreateWitnessReportRequest;
 import com.kuit.findyou.domain.report.dto.request.ReportViewType;
-import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailResponseDTO;
-import com.kuit.findyou.domain.report.service.retrieve.ProtectingReportRetrieveWithS3Service;
+import com.kuit.findyou.domain.report.model.Neutering;
+import com.kuit.findyou.domain.report.model.ProtectingReport;
+import com.kuit.findyou.domain.report.model.ReportTag;
+import com.kuit.findyou.domain.report.model.Sex;
+import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
@@ -23,13 +28,17 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.client.RestTemplate;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.FORBIDDEN;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -42,7 +51,14 @@ class ReportControllerTest {
     private ImageUploader imageUploader;
 
     @MockitoBean
-    private ProtectingReportRetrieveWithS3Service protectingReportRetrieveWithS3Service;
+    private RestTemplate restTemplate;
+
+    @Autowired
+    private ProtectingReportRepository protectingReportRepository;
+
+    @Autowired
+    private ReportImageRepository reportImageRepository;
+
 
     @LocalServerPort
     int port;
@@ -547,26 +563,46 @@ class ReportControllerTest {
     @DisplayName("보호글 랜덤 조회 -> S3 URL 포함 응답")
     void getRandomProtectingReportsWithS3_success() {
         // given
-        User user = testInitializer.userWith3InterestReportsAnd2ViewedReports();
+        User user = testInitializer.createTestUser();
+
         String accessToken = jwtUtil.createAccessJwt(user.getId(), user.getRole());
 
-        ProtectingReportDetailResponseDTO dto = new ProtectingReportDetailResponseDTO(
-                List.of("https://cdn.findyou.store/random1.jpg", "https://cdn.findyou.store/random2.jpg"),
-                "스피츠", "보호중", "1살", "4kg", "흰색",
-                "수컷", "N", "사람을 잘 따름",
-                "인천광역시수의사회", "인천광역시 남동구",
-                37.566239, 126.719642,
-                "032-515-7567",
-                "2025-10-27",
-                "남동구 만수동 993",
-                "2025-10-28 ~ 2025-11-07",
-                "인천-남동-2025-00349",
-                "인천광역시 남동구",
-                false
-        );
+        ProtectingReport report = ProtectingReport.builder()
+                .tag(ReportTag.PROTECTING)
+                .breed("믹스견")
+                .species("강아지")
+                .sex(Sex.M)
+                .age("10")
+                .weight("5kg")
+                .furColor("흰색")
+                .neutering(Neutering.Y)
+                .significant("특이사항 없음")
+                .foundLocation("서울시 광진구")
+                .noticeNumber("12345")
+                .noticeStartDate(LocalDate.now())
+                .noticeEndDate(LocalDate.now().plusDays(10))
+                .careName("광진보호소")
+                .careTel("02-123-4567")
+                .authority("광진구청")
+                .date(LocalDate.now())
+                .address("서울시 광진구")
+                .latitude(BigDecimal.valueOf(37.12345))
+                .longitude(BigDecimal.valueOf(127.12345))
+                .user(user)
+                .build();
 
-        when(protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(1))
-                .thenReturn(List.of(dto));
+        protectingReportRepository.saveAndFlush(report);
+
+        String originalImageUrl = "https://cdn.findyou.store/random1.jpg";
+        ReportImage reportImage = ReportImage.createReportImage(originalImageUrl, report);
+
+        reportImageRepository.saveAndFlush(reportImage);
+
+        when(restTemplate.getForObject(eq(originalImageUrl),eq(byte[].class)))
+                .thenReturn(new byte[]{1, 2, 3});
+
+        when(imageUploader.upload(any(byte[].class), anyString(), eq("image/jpeg")))
+                .thenReturn("https://cdn.findyou.store/random1.jpg");
 
         // when & then
         given()
@@ -574,17 +610,16 @@ class ReportControllerTest {
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .param("count", 1)
-                .when()
+        .when()
                 .get("/api/v2/reports/protecting-reports/random-s3")
-                .then()
+        .then()
                 .statusCode(200)
                 .body("success", equalTo(true))
                 .body("code", equalTo(200))
                 .body("data.size()", equalTo(1))
-                .body("data[0].imageUrls.size()", equalTo(2))
                 .body("data[0].imageUrls[0]", equalTo("https://cdn.findyou.store/random1.jpg"))
-                .body("data[0].breed", equalTo("스피츠"))
+                .body("data[0].breed", equalTo("믹스견"))
                 .body("data[0].tag", equalTo("보호중"))
-                .body("data[0].careName", equalTo("인천광역시수의사회"));
+                .body("data[0].careName", equalTo("광진보호소"));
     }
 }

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -3,6 +3,8 @@ package com.kuit.findyou.domain.report.controller;
 import com.kuit.findyou.domain.report.dto.request.CreateMissingReportRequest;
 import com.kuit.findyou.domain.report.dto.request.CreateWitnessReportRequest;
 import com.kuit.findyou.domain.report.dto.request.ReportViewType;
+import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailResponseDTO;
+import com.kuit.findyou.domain.report.service.retrieve.ProtectingReportRetrieveWithS3Service;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.common.util.TestInitializer;
@@ -28,6 +30,7 @@ import java.util.List;
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.FORBIDDEN;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -37,6 +40,9 @@ class ReportControllerTest {
 
     @MockitoBean
     private ImageUploader imageUploader;
+
+    @MockitoBean
+    private ProtectingReportRetrieveWithS3Service protectingReportRetrieveWithS3Service;
 
     @LocalServerPort
     int port;
@@ -536,5 +542,49 @@ class ReportControllerTest {
                 "서울시 광진구 능동로 120",
                 "건국대학교"
         );
+    }
+    @Test
+    @DisplayName("보호글 랜덤 조회 -> S3 URL 포함 응답")
+    void getRandomProtectingReportsWithS3_success() {
+        // given
+        User user = testInitializer.userWith3InterestReportsAnd2ViewedReports();
+        String accessToken = jwtUtil.createAccessJwt(user.getId(), user.getRole());
+
+        ProtectingReportDetailResponseDTO dto = new ProtectingReportDetailResponseDTO(
+                List.of("https://cdn.findyou.store/random1.jpg", "https://cdn.findyou.store/random2.jpg"),
+                "스피츠", "보호중", "1살", "4kg", "흰색",
+                "수컷", "N", "사람을 잘 따름",
+                "인천광역시수의사회", "인천광역시 남동구",
+                37.566239, 126.719642,
+                "032-515-7567",
+                "2025-10-27",
+                "남동구 만수동 993",
+                "2025-10-28 ~ 2025-11-07",
+                "인천-남동-2025-00349",
+                "인천광역시 남동구",
+                false
+        );
+
+        when(protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(1))
+                .thenReturn(List.of(dto));
+
+        // when & then
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .param("count", 1)
+                .when()
+                .get("/api/v2/reports/protecting-reports/random-s3")
+                .then()
+                .statusCode(200)
+                .body("success", equalTo(true))
+                .body("code", equalTo(200))
+                .body("data.size()", equalTo(1))
+                .body("data[0].imageUrls.size()", equalTo(2))
+                .body("data[0].imageUrls[0]", equalTo("https://cdn.findyou.store/random1.jpg"))
+                .body("data[0].breed", equalTo("스피츠"))
+                .body("data[0].tag", equalTo("보호중"))
+                .body("data[0].careName", equalTo("인천광역시수의사회"));
     }
 }

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
@@ -1,0 +1,97 @@
+package com.kuit.findyou.domain.report.service.retrieve;
+
+import com.kuit.findyou.domain.image.model.ReportImage;
+import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailResponseDTO;
+import com.kuit.findyou.domain.report.model.ProtectingReport;
+import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
+import com.kuit.findyou.domain.report.service.detail.strategy.ProtectingReportDetailStrategy;
+import com.kuit.findyou.global.common.exception.CustomException;
+import com.kuit.findyou.global.infrastructure.ImageUploader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Transactional
+@ActiveProfiles("test")
+class ProtectingReportRetrieveWithS3ServiceImplTest {
+
+    @Mock
+    private ProtectingReportRepository protectingReportRepository;
+
+    @Mock
+    private ImageUploader imageUploader;
+
+    @Mock
+    private ProtectingReportDetailStrategy protectingReportDetailStrategy;
+
+    @InjectMocks
+    private ProtectingReportRetrieveWithS3ServiceImpl protectingReportRetrieveWithS3Service;
+
+    @Test
+    @DisplayName("보호글이 하나도 없으면 PROTECTING_REPORT_NOT_FOUND 예외")
+    void getRandomProtectingReportsWithS3_whenNoReports_thenThrow() {
+        // given
+        when(protectingReportRepository.findAll()).thenReturn(List.of());
+
+        // when & then
+        assertThrows(CustomException.class,
+                () -> protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(3)
+        );
+
+        verify(protectingReportRepository, times(1)).findAll();
+        verifyNoInteractions(imageUploader, protectingReportDetailStrategy);
+    }
+
+    @Test
+    @DisplayName("요청 개수보다 보호글이 적으면 전체 개수만큼만 DTO를 반환한다")
+    void getRandomProtectingReportsWithS3_whenCountGreaterThanSize_thenReturnAllReports() {
+        // given
+        ProtectingReport report1 = mock(ProtectingReport.class);
+        ProtectingReport report2 = mock(ProtectingReport.class);
+
+        // 이미지 없다고 가정
+        when(report1.getReportImages()).thenReturn(Collections.<ReportImage>emptyList());
+        when(report2.getReportImages()).thenReturn(Collections.<ReportImage>emptyList());
+
+        when(protectingReportRepository.findAll())
+                .thenReturn(List.of(report1, report2));
+
+        ProtectingReportDetailResponseDTO dto1 = mock(ProtectingReportDetailResponseDTO.class);
+        ProtectingReportDetailResponseDTO dto2 = mock(ProtectingReportDetailResponseDTO.class);
+
+        when(protectingReportDetailStrategy.toDetailDto(eq(report1), anyList(), eq(false)))
+                .thenReturn(dto1);
+        when(protectingReportDetailStrategy.toDetailDto(eq(report2), anyList(), eq(false)))
+                .thenReturn(dto2);
+
+        // when
+        List<ProtectingReportDetailResponseDTO> result =
+                protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(10);
+
+        // then
+        assertThat(result)
+                .hasSize(2)
+                .containsExactlyInAnyOrder(dto1, dto2);
+
+        verify(protectingReportRepository, times(1)).findAll();
+        verify(protectingReportDetailStrategy, times(2))
+                .toDetailDto(any(ProtectingReport.class), anyList(), eq(false));
+
+        // 이미지가 없어서 upload는 호출 X
+        verifyNoInteractions(imageUploader);
+    }
+}

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
@@ -13,9 +13,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -27,6 +31,8 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 @Transactional
 @ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ProtectingReportRetrieveWithS3ServiceImplTest {
 
     @Mock
@@ -37,6 +43,9 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
 
     @Mock
     private ProtectingReportDetailStrategy protectingReportDetailStrategy;
+
+    @Mock
+    private RestTemplate restTemplate;
 
     @InjectMocks
     private ProtectingReportRetrieveWithS3ServiceImpl protectingReportRetrieveWithS3Service;
@@ -93,5 +102,65 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
 
         // 이미지가 없어서 upload는 호출 X
         verifyNoInteractions(imageUploader);
+    }
+
+    @Test
+    @DisplayName("요청 개수가 전체 개수보다 적으면 요청 개수만큼만 반환한다")
+    void getRandomProtectingReportsWithS3_whenCountLessThanSize_thenReturnCountReports() {
+        // given (보호글 3개, count=2)
+        ProtectingReport r1 = mock(ProtectingReport.class);
+        ProtectingReport r2 = mock(ProtectingReport.class);
+        ProtectingReport r3 = mock(ProtectingReport.class);
+
+        when(r1.getReportImages()).thenReturn(Collections.emptyList());
+        when(r2.getReportImages()).thenReturn(Collections.emptyList());
+        when(r3.getReportImages()).thenReturn(Collections.emptyList());
+
+        when(protectingReportRepository.findAll())
+                .thenReturn(new ArrayList<>(List.of(r1, r2, r3)));
+
+        when(protectingReportDetailStrategy.toDetailDto(any(), anyList(), eq(false)))
+                .thenReturn(mock(ProtectingReportDetailResponseDTO.class));
+
+        // when
+        List<ProtectingReportDetailResponseDTO> result =
+                protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(2);
+
+        // then
+        assertThat(result).hasSize(2);
+
+        verify(protectingReportRepository).findAll();
+        verify(protectingReportDetailStrategy, times(2))
+                .toDetailDto(any(ProtectingReport.class), anyList(), eq(false));
+        verifyNoInteractions(imageUploader, restTemplate);
+    }
+
+    @Test
+    @DisplayName("이미지 처리 중 예기치 못한 예외가 나도 전체 API는 실패하지 않는다")
+    void getRandomProtectingReportsWithS3_whenUnexpectedException_thenContinue() {
+        // given
+        ProtectingReport report = mock(ProtectingReport.class);
+        when(report.getId()).thenReturn(1L);
+
+        // 존재하지 않는 로컬 포트로 URL 세팅 → RestTemplate 호출 시 예외 발생
+        ReportImage img1 = mock(ReportImage.class);
+        when(img1.getImageUrl()).thenReturn("http://localhost:65535/nonexistent");
+
+        when(report.getReportImages()).thenReturn(List.of(img1));
+        when(protectingReportRepository.findAll())
+                .thenReturn(new ArrayList<>(List.of(report)));
+
+        ProtectingReportDetailResponseDTO dto = mock(ProtectingReportDetailResponseDTO.class);
+        when(protectingReportDetailStrategy.toDetailDto(eq(report), anyList(), eq(false)))
+                .thenReturn(dto);
+
+        // when
+        List<ProtectingReportDetailResponseDTO> result =
+                protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(1);
+
+        // then (예외 X, DTO는 정상적으로 하나 반환)
+        assertThat(result)
+                .hasSize(1)
+                .containsExactly(dto);
     }
 }

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.test.util.ReflectionTestUtils;
+import com.kuit.findyou.global.infrastructure.FileUploadingFailedException;
 
 @ExtendWith(MockitoExtension.class)
 @Transactional
@@ -232,4 +233,57 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         verify(imageUploader, times(2))
                 .upload(any(byte[].class), anyString(), eq("image/jpeg"));
     }
+
+    @Test
+    @DisplayName("S3 업로드나 이미지 처리에사 예외가 발생해도 DTO는 정상 반환된다")
+    void getRandomProtectingReportsWithS3_whenUploadFails_thenContinuePerImage() {
+        // given
+        ProtectingReport report = mock(ProtectingReport.class);
+        when(report.getId()).thenReturn(200L);
+
+        //첫 번째는 S3 업로드 실패, 두 번째는 다운로드 단계 예외
+        ReportImage img1 = mock(ReportImage.class);
+        ReportImage img2 = mock(ReportImage.class);
+        when(img1.getImageUrl()).thenReturn("http://example.com/1.jpg");
+        when(img2.getImageUrl()).thenReturn("http://example.com/2.jpg");
+        when(report.getReportImages()).thenReturn(List.of(img1, img2));
+
+        when(protectingReportRepository.findAll())
+                .thenReturn(new ArrayList<>(List.of(report)));
+
+        //1번 이미지는 S3 업로드 시 FileUploadingFailedException 발생
+        when(restTemplate.getForObject("http://example.com/1.jpg", byte[].class))
+                .thenReturn(new byte[]{1, 2, 3});
+        when(imageUploader.upload(any(byte[].class), anyString(), eq("image/jpeg")))
+                .thenThrow(new FileUploadingFailedException("업로드 실패"));
+
+        //2번 이미지는 다운로드 단계에서 바로 RuntimeException
+        when(restTemplate.getForObject("http://example.com/2.jpg", byte[].class))
+                .thenThrow(new RuntimeException("다운로드 오류"));
+
+        ProtectingReportDetailResponseDTO dto = mock(ProtectingReportDetailResponseDTO.class);
+        ArgumentCaptor<List<String>> s3UrlsCaptor = ArgumentCaptor.forClass(List.class);
+        when(protectingReportDetailStrategy.toDetailDto(eq(report), s3UrlsCaptor.capture(), eq(false)))
+                .thenReturn(dto);
+
+        // when
+        List<ProtectingReportDetailResponseDTO> result =
+                protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(1);
+
+        // then
+        //전체 API는 죽지 않고 DTO 하나는 정상 반환
+        assertThat(result).hasSize(1).containsExactly(dto);
+
+        //두 이미지 모두 실패했으므로 이미지는 빈값
+        assertThat(s3UrlsCaptor.getValue()).isEmpty();
+
+        //예외가 던져지지 않음
+        verify(restTemplate, times(1))
+                .getForObject("http://example.com/1.jpg", byte[].class);
+        verify(restTemplate, times(1))
+                .getForObject("http://example.com/2.jpg", byte[].class);
+        verify(imageUploader, times(1))
+                .upload(any(byte[].class), anyString(), eq("image/jpeg"));
+    }
+
 }

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
@@ -6,6 +6,7 @@ import com.kuit.findyou.domain.report.model.ProtectingReport;
 import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
 import com.kuit.findyou.domain.report.service.detail.strategy.ProtectingReportDetailStrategy;
 import com.kuit.findyou.global.common.exception.CustomException;
+import com.kuit.findyou.global.infrastructure.FileUploadingFailedException;
 import com.kuit.findyou.global.infrastructure.ImageUploader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
@@ -28,9 +30,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import org.junit.jupiter.api.BeforeEach;
-import org.springframework.test.util.ReflectionTestUtils;
-import com.kuit.findyou.global.infrastructure.FileUploadingFailedException;
 
 @ExtendWith(MockitoExtension.class)
 @Transactional
@@ -54,28 +53,18 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
     @InjectMocks
     private ProtectingReportRetrieveWithS3ServiceImpl protectingReportRetrieveWithS3Service;
 
-    @BeforeEach
-    void injectRestTemplateMock() {
-        //mock RestTemplate 주입
-        ReflectionTestUtils.setField(
-                protectingReportRetrieveWithS3Service,
-                "restTemplate",
-                restTemplate
-        );
-    }
-
     @Test
     @DisplayName("보호글이 하나도 없으면 PROTECTING_REPORT_NOT_FOUND 예외")
     void getRandomProtectingReportsWithS3_whenNoReports_thenThrow() {
         // given
-        when(protectingReportRepository.findAll()).thenReturn(List.of());
+        when(protectingReportRepository.findRandomReports(any(Pageable.class))).thenReturn(List.of());
 
         // when & then
         assertThrows(CustomException.class,
                 () -> protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(3)
         );
 
-        verify(protectingReportRepository, times(1)).findAll();
+        verify(protectingReportRepository, times(1)).findRandomReports(any(Pageable.class));
         verifyNoInteractions(imageUploader, protectingReportDetailStrategy);
     }
 
@@ -90,8 +79,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(report1.getReportImages()).thenReturn(Collections.<ReportImage>emptyList());
         when(report2.getReportImages()).thenReturn(Collections.<ReportImage>emptyList());
 
-        when(protectingReportRepository.findAll())
-                .thenReturn(List.of(report1, report2));
+        when(protectingReportRepository.findRandomReports(any(Pageable.class))).thenReturn(List.of(report1, report2));
 
         ProtectingReportDetailResponseDTO dto1 = mock(ProtectingReportDetailResponseDTO.class);
         ProtectingReportDetailResponseDTO dto2 = mock(ProtectingReportDetailResponseDTO.class);
@@ -110,7 +98,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
                 .hasSize(2)
                 .containsExactlyInAnyOrder(dto1, dto2);
 
-        verify(protectingReportRepository, times(1)).findAll();
+        verify(protectingReportRepository, times(1)).findRandomReports(any(Pageable.class));
         verify(protectingReportDetailStrategy, times(2))
                 .toDetailDto(any(ProtectingReport.class), anyList(), eq(false));
 
@@ -130,8 +118,8 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(r2.getReportImages()).thenReturn(Collections.emptyList());
         when(r3.getReportImages()).thenReturn(Collections.emptyList());
 
-        when(protectingReportRepository.findAll())
-                .thenReturn(new ArrayList<>(List.of(r1, r2, r3)));
+        when(protectingReportRepository.findRandomReports(any(Pageable.class)))
+                .thenReturn(new ArrayList<>(List.of(r1, r2)));
 
         when(protectingReportDetailStrategy.toDetailDto(any(), anyList(), eq(false)))
                 .thenReturn(mock(ProtectingReportDetailResponseDTO.class));
@@ -143,10 +131,9 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         // then
         assertThat(result).hasSize(2);
 
-        verify(protectingReportRepository).findAll();
+        verify(protectingReportRepository).findRandomReports(any(Pageable.class));
         verify(protectingReportDetailStrategy, times(2))
                 .toDetailDto(any(ProtectingReport.class), anyList(), eq(false));
-        verifyNoInteractions(imageUploader, restTemplate);
     }
 
     @Test
@@ -161,7 +148,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(img1.getImageUrl()).thenReturn("http://localhost:65535/nonexistent");
 
         when(report.getReportImages()).thenReturn(List.of(img1));
-        when(protectingReportRepository.findAll())
+        when(protectingReportRepository.findRandomReports(any(Pageable.class)))
                 .thenReturn(new ArrayList<>(List.of(report)));
 
         ProtectingReportDetailResponseDTO dto = mock(ProtectingReportDetailResponseDTO.class);
@@ -190,7 +177,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(img2.getImageUrl()).thenReturn("http://example.com/2.jpg");
         when(report.getReportImages()).thenReturn(List.of(img1, img2));
 
-        when(protectingReportRepository.findAll())
+        when(protectingReportRepository.findRandomReports(any(Pageable.class)))
                 .thenReturn(new ArrayList<>(List.of(report)));
 
         // RestTemplate 가 바이트 배열 내려줌
@@ -248,7 +235,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(img2.getImageUrl()).thenReturn("http://example.com/2.jpg");
         when(report.getReportImages()).thenReturn(List.of(img1, img2));
 
-        when(protectingReportRepository.findAll())
+        when(protectingReportRepository.findRandomReports(any(Pageable.class)))
                 .thenReturn(new ArrayList<>(List.of(report)));
 
         //1번 이미지는 S3 업로드 시 FileUploadingFailedException 발생

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
@@ -235,7 +235,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
     }
 
     @Test
-    @DisplayName("S3 업로드나 이미지 처리에사 예외가 발생해도 DTO는 정상 반환된다")
+    @DisplayName("S3 업로드나 이미지 처리에서 예외가 발생해도 DTO는 정상 반환된다")
     void getRandomProtectingReportsWithS3_whenUploadFails_thenContinuePerImage() {
         // given
         ProtectingReport report = mock(ProtectingReport.class);

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
@@ -10,6 +10,7 @@ import com.kuit.findyou.global.infrastructure.ImageUploader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -27,6 +28,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @Transactional
@@ -49,6 +52,16 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
 
     @InjectMocks
     private ProtectingReportRetrieveWithS3ServiceImpl protectingReportRetrieveWithS3Service;
+
+    @BeforeEach
+    void injectRestTemplateMock() {
+        //mock RestTemplate 주입
+        ReflectionTestUtils.setField(
+                protectingReportRetrieveWithS3Service,
+                "restTemplate",
+                restTemplate
+        );
+    }
 
     @Test
     @DisplayName("보호글이 하나도 없으면 PROTECTING_REPORT_NOT_FOUND 예외")
@@ -162,5 +175,61 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         assertThat(result)
                 .hasSize(1)
                 .containsExactly(dto);
+    }
+    @Test
+    @DisplayName("이미지를 정상적으로 받으면 S3에 업로드 &  업로드된 URL로 DTO 생성")
+    void getRandomProtectingReportsWithS3_successUploadFlow() {
+        // given
+        ProtectingReport report = mock(ProtectingReport.class);
+        when(report.getId()).thenReturn(100L);
+
+        ReportImage img1 = mock(ReportImage.class);
+        ReportImage img2 = mock(ReportImage.class);
+        when(img1.getImageUrl()).thenReturn("http://example.com/1.jpg");
+        when(img2.getImageUrl()).thenReturn("http://example.com/2.jpg");
+        when(report.getReportImages()).thenReturn(List.of(img1, img2));
+
+        when(protectingReportRepository.findAll())
+                .thenReturn(new ArrayList<>(List.of(report)));
+
+        // RestTemplate 가 바이트 배열 내려줌
+        when(restTemplate.getForObject(eq("http://example.com/1.jpg"), eq(byte[].class)))
+                .thenReturn(new byte[]{1, 2, 3});
+        when(restTemplate.getForObject(eq("http://example.com/2.jpg"), eq(byte[].class)))
+                .thenReturn(new byte[]{4, 5, 6});
+
+        // S3 업로더는 순서대로 두 번 URL을 반환
+        when(imageUploader.upload(any(byte[].class), anyString(), eq("image/jpeg")))
+                .thenReturn(
+                        "https://s3.findyou.store/1.jpg",
+                        "https://s3.findyou.store/2.jpg"
+                );
+
+        ProtectingReportDetailResponseDTO dto = mock(ProtectingReportDetailResponseDTO.class);
+
+        ArgumentCaptor<List<String>> s3UrlsCaptor = ArgumentCaptor.forClass(List.class);
+        when(protectingReportDetailStrategy.toDetailDto(eq(report), s3UrlsCaptor.capture(), eq(false)))
+                .thenReturn(dto);
+
+        // when
+        List<ProtectingReportDetailResponseDTO> result =
+                protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(1);
+
+        // then
+        assertThat(result).hasSize(1).containsExactly(dto);
+
+        List<String> capturedUrls = s3UrlsCaptor.getValue();
+        assertThat(capturedUrls)
+                .containsExactly(
+                        "https://s3.findyou.store/1.jpg",
+                        "https://s3.findyou.store/2.jpg"
+                );
+
+        verify(restTemplate, times(1))
+                .getForObject("http://example.com/1.jpg", byte[].class);
+        verify(restTemplate, times(1))
+                .getForObject("http://example.com/2.jpg", byte[].class);
+        verify(imageUploader, times(2))
+                .upload(any(byte[].class), anyString(), eq("image/jpeg"));
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -31,6 +31,8 @@ findyou:
     access:
       expire-ms: 6000000
     secret-key : secretkey1224secretkey1224secretkey1224secretkey1224
+  home-stats:
+    parsing-timeout-sec: 20
 
 cloud:
   aws:


### PR DESCRIPTION
## Related issue 🛠
- closed #144 

## Work Description 📝
- 파이썬 스케줄러에서 호출해서 인스타그램 홍보용 컨텐츠 자동 생성에 활용할 용도로, 새로운 API를 개발했습니다.

- 공공 API에서 가져온 보호글 원본 이미지 URL들을 이용해, 서버가 직접 이미지를 받아 S3(CDN 도메인)로 업로드한 뒤, 업로드된 S3 URL을 포함한 보호글 상세 정보 리스트를 반환하는 API입니다.

- 보호글 상세 DTO를 만드는 로직을 한 곳에서 관리하면서, 상황에 따라 다른 이미지 URL 리스트만 주입할 수 있도록 하기 위해 공통 매핑 메서드를 도입했습니다.  (ProtectingReportDetailStrategy)

- 현재는 count 파라미터 값을 1에서 10 까지만 입력 가능하도록 구현해 두었습니다. 홍보용으로 하루에 1개에서 3개만 필요하다고 말씀하셨어서 이렇게 설정해두었는데, 변경이 필요할 것 같으면 말씀 부탁드립니다! 

## Screenshot 📸
<img width="1804" height="1458" alt="image" src="https://github.com/user-attachments/assets/03137068-90a9-4744-9371-7853a81ba86a" />

## Uncompleted Tasks 😅

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 임의의 보호 보고서를 S3 이미지와 함께 조회하는 새로운 API 엔드포인트 추가
  * count 파라미터를 통해 조회할 보고서 개수를 지정 가능 (기본값: 1)

* **테스트**
  * 새로운 API 엔드포인트 및 서비스 로직에 대한 테스트 케이스 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->