### PR TITLE
[Refactor] S3 URL 반환하는 보호글 랜덤 조회 기능 수정

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -7,7 +7,7 @@ import com.kuit.findyou.domain.report.dto.response.CardResponseDTO;
 import com.kuit.findyou.domain.report.dto.response.MissingReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.dto.response.WitnessReportDetailResponseDTO;
-import com.kuit.findyou.domain.report.model.*;
+import com.kuit.findyou.domain.report.model.ReportTag;
 import com.kuit.findyou.domain.report.service.facade.ReportServiceFacade;
 import com.kuit.findyou.domain.report.service.retrieve.ProtectingReportRetrieveWithS3Service;
 import com.kuit.findyou.global.common.annotation.CustomExceptionDescription;
@@ -21,6 +21,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -119,14 +120,17 @@ public class ReportController {
     @Operation(summary = "보호글 S3 이미지 포함 랜덤 조회 API", description = "랜덤으로 보호글을 선택하여 원본 이미지를 S3에 업로드 후, S3 URL 포함 보호글을 리스트로 반환합니다.")
     @GetMapping("/protecting-reports/random-s3")
     @CustomExceptionDescription(DEFAULT)
-    public BaseResponse<List<ProtectingReportDetailResponseDTO>> getRandomProtectingReportsWithS3(
+    public ResponseEntity<?> getRandomProtectingReportsWithS3(
             @RequestParam(name = "count", defaultValue = "1")
              @Min(1) @Max(10) int count
     ) {
         List<ProtectingReportDetailResponseDTO> details =
                 protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(count);
 
-        return BaseResponse.ok(details);
+        if (details.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(BaseResponse.ok(details));
     }
 
 }

--- a/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
@@ -1,12 +1,11 @@
 package com.kuit.findyou.domain.report.repository;
 
 import com.kuit.findyou.domain.report.model.ProtectingReport;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -19,7 +18,6 @@ public interface ProtectingReportRepository extends JpaRepository<ProtectingRepo
 
     List<ProtectingReport> findByNoticeNumberIn(Set<String> noticeNumbers);
 
-    @Query("SELECT p FROM ProtectingReport p ORDER BY function('RAND')")
-    List<ProtectingReport> findRandomReports(Pageable pageable);
+    List<ProtectingReport> findByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
 }
 

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
@@ -5,21 +5,20 @@ import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailRespons
 import com.kuit.findyou.domain.report.model.ProtectingReport;
 import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
 import com.kuit.findyou.domain.report.service.detail.strategy.ProtectingReportDetailStrategy;
-import com.kuit.findyou.global.common.exception.CustomException;
 import com.kuit.findyou.global.infrastructure.FileUploadingFailedException;
 import com.kuit.findyou.global.infrastructure.ImageUploader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-
-import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.PROTECTING_REPORT_NOT_FOUND;
 
 @RequiredArgsConstructor
 @Service
@@ -36,17 +35,22 @@ public class ProtectingReportRetrieveWithS3ServiceImpl implements ProtectingRepo
     @Transactional(readOnly = true)
     public List<ProtectingReportDetailResponseDTO> getRandomProtectingReportsWithS3(int count) {
 
-        int limit = Math.max(1, count);
+        LocalDateTime end = LocalDateTime.now();
+        LocalDateTime start = LocalDate.now().minusDays(1).atStartOfDay();
+        List<ProtectingReport> allReports = protectingReportRepository.findByCreatedAtBetween(start, end);
 
-        //랜덤으로 count 만큼 조회
-        List<ProtectingReport> reports = protectingReportRepository.findRandomReports(PageRequest.of(0, limit));
-        if(reports.isEmpty()) {
-            throw new CustomException(PROTECTING_REPORT_NOT_FOUND);
+        if(allReports.isEmpty()) {
+            //204 no content
+            return Collections.emptyList();
         }
+
+        Collections.shuffle(allReports);
+
+        List<ProtectingReport> selectedReports = allReports.stream().limit(count).toList();
 
         List<ProtectingReportDetailResponseDTO> result = new ArrayList<>();
 
-        for(ProtectingReport report : reports) {
+        for(ProtectingReport report : selectedReports) {
 
             //보호글에 연결된 원본 이미지 가져오기
             List<ReportImage> reportImages = report.getReportImages();

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +36,7 @@ public class ProtectingReportRetrieveWithS3ServiceImpl implements ProtectingRepo
     @Transactional(readOnly = true)
     public List<ProtectingReportDetailResponseDTO> getRandomProtectingReportsWithS3(int count) {
 
-        LocalDateTime end = LocalDateTime.now();
+        LocalDateTime end = LocalDate.now().atTime(LocalTime.MAX);
         LocalDateTime start = LocalDate.now().minusDays(1).atStartOfDay();
         List<ProtectingReport> allReports = protectingReportRepository.findByCreatedAtBetween(start, end);
 

--- a/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
+++ b/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v2/auth/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v2/users").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v2/users/check/duplicate-nickname").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v2/reports/protecting-reports/random-s3").permitAll()
                         .anyRequest().authenticated());
 
         // 토큰 검증 필터 추가

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -28,10 +28,12 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.FORBIDDEN;
@@ -565,8 +567,6 @@ class ReportControllerTest {
         // given
         User user = testInitializer.createTestUser();
 
-        //String accessToken = jwtUtil.createAccessJwt(user.getId(), user.getRole());
-
         ProtectingReport report = ProtectingReport.builder()
                 .tag(ReportTag.PROTECTING)
                 .breed("믹스견")
@@ -590,7 +590,7 @@ class ReportControllerTest {
                 .longitude(BigDecimal.valueOf(127.12345))
                 .user(user)
                 .build();
-
+        ReflectionTestUtils.setField(report, "createdAt", LocalDateTime.now());
         protectingReportRepository.saveAndFlush(report);
 
         String originalImageUrl = "https://cdn.findyou.store/random1.jpg";

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -590,7 +590,7 @@ class ReportControllerTest {
                 .longitude(BigDecimal.valueOf(127.12345))
                 .user(user)
                 .build();
-        ReflectionTestUtils.setField(report, "createdAt", LocalDateTime.now().minusHours(1));
+        ReflectionTestUtils.setField(report, "createdAt", LocalDateTime.now().minusDays(1));
         protectingReportRepository.saveAndFlush(report);
 
         String originalImageUrl = "https://cdn.findyou.store/random1.jpg";

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -565,7 +565,7 @@ class ReportControllerTest {
         // given
         User user = testInitializer.createTestUser();
 
-        String accessToken = jwtUtil.createAccessJwt(user.getId(), user.getRole());
+        //String accessToken = jwtUtil.createAccessJwt(user.getId(), user.getRole());
 
         ProtectingReport report = ProtectingReport.builder()
                 .tag(ReportTag.PROTECTING)
@@ -606,13 +606,13 @@ class ReportControllerTest {
 
         // when & then
         given()
-                .header("Authorization", "Bearer " + accessToken)
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .param("count", 1)
         .when()
                 .get("/api/v2/reports/protecting-reports/random-s3")
         .then()
+                .log().all()
                 .statusCode(200)
                 .body("success", equalTo(true))
                 .body("code", equalTo(200))
@@ -621,5 +621,23 @@ class ReportControllerTest {
                 .body("data[0].breed", equalTo("믹스견"))
                 .body("data[0].tag", equalTo("보호중"))
                 .body("data[0].careName", equalTo("광진보호소"));
+    }
+
+    @Test
+    @DisplayName("보호글이 없을 경우 -> 204 No Content 응답 (Body 없음)")
+    void getRandomProtectingReportsWithS3_noContent() {
+        // given
+        //DB에 아무것도 저장하지 않음 (빈 상태)
+
+        // when & then
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .param("count", 1)
+                .when()
+                .get("/api/v2/reports/protecting-reports/random-s3")
+                .then()
+                .log().all()
+                .statusCode(204);
     }
 }

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -1,14 +1,10 @@
 package com.kuit.findyou.domain.report.controller;
 
-import com.kuit.findyou.domain.image.model.ReportImage;
 import com.kuit.findyou.domain.image.repository.ReportImageRepository;
 import com.kuit.findyou.domain.report.dto.request.CreateMissingReportRequest;
 import com.kuit.findyou.domain.report.dto.request.CreateWitnessReportRequest;
 import com.kuit.findyou.domain.report.dto.request.ReportViewType;
-import com.kuit.findyou.domain.report.model.Neutering;
 import com.kuit.findyou.domain.report.model.ProtectingReport;
-import com.kuit.findyou.domain.report.model.ReportTag;
-import com.kuit.findyou.domain.report.model.Sex;
 import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
@@ -28,12 +24,9 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.FORBIDDEN;
@@ -566,36 +559,11 @@ class ReportControllerTest {
     void getRandomProtectingReportsWithS3_success() {
         // given
         User user = testInitializer.createTestUser();
+        ProtectingReport report = testInitializer.createTestProtectingReportWithImage(user);
 
-        ProtectingReport report = ProtectingReport.builder()
-                .tag(ReportTag.PROTECTING)
-                .breed("믹스견")
-                .species("강아지")
-                .sex(Sex.M)
-                .age("10")
-                .weight("5kg")
-                .furColor("흰색")
-                .neutering(Neutering.Y)
-                .significant("특이사항 없음")
-                .foundLocation("서울시 광진구")
-                .noticeNumber("12345")
-                .noticeStartDate(LocalDate.now())
-                .noticeEndDate(LocalDate.now().plusDays(10))
-                .careName("광진보호소")
-                .careTel("02-123-4567")
-                .authority("광진구청")
-                .date(LocalDate.now())
-                .address("서울시 광진구")
-                .latitude(BigDecimal.valueOf(37.12345))
-                .longitude(BigDecimal.valueOf(127.12345))
-                .user(user)
-                .build();
         protectingReportRepository.saveAndFlush(report);
 
-        String originalImageUrl = "https://cdn.findyou.store/random1.jpg";
-        ReportImage reportImage = ReportImage.createReportImage(originalImageUrl, report);
-
-        reportImageRepository.saveAndFlush(reportImage);
+        String originalImageUrl = "https://img.com/1.png";
 
         when(restTemplate.getForObject(eq(originalImageUrl),eq(byte[].class)))
                 .thenReturn(new byte[]{1, 2, 3});

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -590,7 +590,7 @@ class ReportControllerTest {
                 .longitude(BigDecimal.valueOf(127.12345))
                 .user(user)
                 .build();
-        ReflectionTestUtils.setField(report, "createdAt", LocalDateTime.now());
+        ReflectionTestUtils.setField(report, "createdAt", LocalDateTime.now().minusHours(1));
         protectingReportRepository.saveAndFlush(report);
 
         String originalImageUrl = "https://cdn.findyou.store/random1.jpg";

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -590,7 +590,6 @@ class ReportControllerTest {
                 .longitude(BigDecimal.valueOf(127.12345))
                 .user(user)
                 .build();
-        ReflectionTestUtils.setField(report, "createdAt", LocalDateTime.now().minusDays(1));
         protectingReportRepository.saveAndFlush(report);
 
         String originalImageUrl = "https://cdn.findyou.store/random1.jpg";

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
@@ -121,7 +121,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(r3.getReportImages()).thenReturn(Collections.emptyList());
 
         when(protectingReportRepository.findByCreatedAtBetween(any(), any()))
-                .thenReturn(new ArrayList<>(List.of(r1, r2)));
+                .thenReturn(new ArrayList<>(List.of(r1, r2, r3)));
 
         when(protectingReportDetailStrategy.toDetailDto(any(), anyList(), eq(false)))
                 .thenReturn(mock(ProtectingReportDetailResponseDTO.class));

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
@@ -64,7 +64,6 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         // then
         assertThat(result).isEmpty();
 
-        // countBy 호출 확인 삭제, findBy 호출 확인
         verify(protectingReportRepository, times(1))
                 .findByCreatedAtBetween(any(LocalDateTime.class), any(LocalDateTime.class));
 

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
@@ -52,7 +52,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
     private ProtectingReportRetrieveWithS3ServiceImpl protectingReportRetrieveWithS3Service;
 
     @Test
-    @DisplayName("어제, 오늘 게시된 보호글이 하나도 없으면 204")
+    @DisplayName("어제, 오늘 게시된 보호글이 하나도 없으면 빈 리스트를 반환")
     void getRandomProtectingReportsWithS3_whenNoReports_thenThrow() {
         // given
         when(protectingReportRepository.findByCreatedAtBetween(any(LocalDateTime.class), any(LocalDateTime.class))).thenReturn(Collections.emptyList());

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
@@ -5,7 +5,6 @@ import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailRespons
 import com.kuit.findyou.domain.report.model.ProtectingReport;
 import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
 import com.kuit.findyou.domain.report.service.detail.strategy.ProtectingReportDetailStrategy;
-import com.kuit.findyou.global.common.exception.CustomException;
 import com.kuit.findyou.global.infrastructure.FileUploadingFailedException;
 import com.kuit.findyou.global.infrastructure.ImageUploader;
 import org.junit.jupiter.api.DisplayName;
@@ -17,17 +16,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -54,17 +52,22 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
     private ProtectingReportRetrieveWithS3ServiceImpl protectingReportRetrieveWithS3Service;
 
     @Test
-    @DisplayName("보호글이 하나도 없으면 PROTECTING_REPORT_NOT_FOUND 예외")
+    @DisplayName("어제, 오늘 게시된 보호글이 하나도 없으면 204")
     void getRandomProtectingReportsWithS3_whenNoReports_thenThrow() {
         // given
-        when(protectingReportRepository.findRandomReports(any(Pageable.class))).thenReturn(List.of());
+        when(protectingReportRepository.findByCreatedAtBetween(any(LocalDateTime.class), any(LocalDateTime.class))).thenReturn(Collections.emptyList());
 
-        // when & then
-        assertThrows(CustomException.class,
-                () -> protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(3)
-        );
+        // when
+        List<ProtectingReportDetailResponseDTO> result =
+                protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(3);
 
-        verify(protectingReportRepository, times(1)).findRandomReports(any(Pageable.class));
+        // then
+        assertThat(result).isEmpty();
+
+        // countBy 호출 확인 삭제, findBy 호출 확인
+        verify(protectingReportRepository, times(1))
+                .findByCreatedAtBetween(any(LocalDateTime.class), any(LocalDateTime.class));
+
         verifyNoInteractions(imageUploader, protectingReportDetailStrategy);
     }
 
@@ -79,7 +82,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(report1.getReportImages()).thenReturn(Collections.<ReportImage>emptyList());
         when(report2.getReportImages()).thenReturn(Collections.<ReportImage>emptyList());
 
-        when(protectingReportRepository.findRandomReports(any(Pageable.class))).thenReturn(List.of(report1, report2));
+        when(protectingReportRepository.findByCreatedAtBetween(any(), any())).thenReturn(new ArrayList<>(List.of(report1, report2)));
 
         ProtectingReportDetailResponseDTO dto1 = mock(ProtectingReportDetailResponseDTO.class);
         ProtectingReportDetailResponseDTO dto2 = mock(ProtectingReportDetailResponseDTO.class);
@@ -98,7 +101,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
                 .hasSize(2)
                 .containsExactlyInAnyOrder(dto1, dto2);
 
-        verify(protectingReportRepository, times(1)).findRandomReports(any(Pageable.class));
+        verify(protectingReportRepository, times(1)).findByCreatedAtBetween(any(), any());
         verify(protectingReportDetailStrategy, times(2))
                 .toDetailDto(any(ProtectingReport.class), anyList(), eq(false));
 
@@ -118,7 +121,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(r2.getReportImages()).thenReturn(Collections.emptyList());
         when(r3.getReportImages()).thenReturn(Collections.emptyList());
 
-        when(protectingReportRepository.findRandomReports(any(Pageable.class)))
+        when(protectingReportRepository.findByCreatedAtBetween(any(), any()))
                 .thenReturn(new ArrayList<>(List.of(r1, r2)));
 
         when(protectingReportDetailStrategy.toDetailDto(any(), anyList(), eq(false)))
@@ -131,7 +134,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         // then
         assertThat(result).hasSize(2);
 
-        verify(protectingReportRepository).findRandomReports(any(Pageable.class));
+        verify(protectingReportRepository).findByCreatedAtBetween(any(), any());
         verify(protectingReportDetailStrategy, times(2))
                 .toDetailDto(any(ProtectingReport.class), anyList(), eq(false));
     }
@@ -148,7 +151,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(img1.getImageUrl()).thenReturn("http://localhost:65535/nonexistent");
 
         when(report.getReportImages()).thenReturn(List.of(img1));
-        when(protectingReportRepository.findRandomReports(any(Pageable.class)))
+        when(protectingReportRepository.findByCreatedAtBetween(any(), any()))
                 .thenReturn(new ArrayList<>(List.of(report)));
 
         ProtectingReportDetailResponseDTO dto = mock(ProtectingReportDetailResponseDTO.class);
@@ -177,7 +180,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(img2.getImageUrl()).thenReturn("http://example.com/2.jpg");
         when(report.getReportImages()).thenReturn(List.of(img1, img2));
 
-        when(protectingReportRepository.findRandomReports(any(Pageable.class)))
+        when(protectingReportRepository.findByCreatedAtBetween(any(), any()))
                 .thenReturn(new ArrayList<>(List.of(report)));
 
         // RestTemplate 가 바이트 배열 내려줌
@@ -235,7 +238,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(img2.getImageUrl()).thenReturn("http://example.com/2.jpg");
         when(report.getReportImages()).thenReturn(List.of(img1, img2));
 
-        when(protectingReportRepository.findRandomReports(any(Pageable.class)))
+        when(protectingReportRepository.findByCreatedAtBetween(any(), any()))
                 .thenReturn(new ArrayList<>(List.of(report)));
 
         //1번 이미지는 S3 업로드 시 FileUploadingFailedException 발생


### PR DESCRIPTION
## Related issue 🛠
- closed #146 

## Work Description 📝
- 요청에 따라 해당 API에서는 jwt 인증 과정을 생략하도록 했습니다.
- 랜덤 조회시, 전체 보호글에서 랜덤으로 조회하는 방식 -> 요청 시점 기준으로 전날, 오늘 생성된 보호글 중 요청 파라미터 개수만큼 랜덤 조회하는 방식으로 변경했습니다. (create_at 필드를 기준으로)
- 요청에 따라 이틀동안 게시된 보호글이 없는 경우 baseResponse가 아닌, 204 HTTP 응답을 내리도록 변경했습니다.
- 테스트 코드를 변경했습니다.

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [x] 로컬에서 문제없이 pass 되어 PR을 올렸는데, 컨트롤러 테스트가 CI 환경에서 실패하는 것 같습니다. 테스트 시에 LocalDateTime.now()를 사용하여 createdat()을 주입했는데, 서버 시간이 한국 기준이 아니라 그런 것 같습니다. 이부분 빠르게 해결해보겠습니다! 

## To Reviewers 📢

