### PR TITLE
[Feat] 토큰 재발급 API 구현

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -35,7 +35,6 @@ public class AuthController {
     @CustomExceptionDescription(KAKAO_LOGIN)
     @PostMapping("/login/kakao")
     public BaseResponse<KakaoLoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request){
-        log.info("[kakaoLogin] ");
         return BaseResponse.ok(authServiceFacade.kakaoLogin(request));
     }
 
@@ -57,7 +56,6 @@ public class AuthController {
     @CustomExceptionDescription(REISSUE_TOKEN)
     @PostMapping("/reissue/token")
     public BaseResponse<ReissueTokenResponse> reissueToken(@RequestBody ReissueTokenRequest request){
-        log.debug("[reissueToken] request.refreshToken = {}", request.refreshToken());
         return BaseResponse.ok(authServiceFacade.reissueToken(request));
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -6,8 +6,7 @@ import com.kuit.findyou.domain.auth.dto.request.GuestLoginRequest;
 import com.kuit.findyou.domain.auth.dto.response.GuestLoginResponse;
 import com.kuit.findyou.domain.auth.dto.request.KakaoLoginRequest;
 import com.kuit.findyou.domain.auth.dto.response.KakaoLoginResponse;
-import com.kuit.findyou.domain.auth.service.LoginService;
-import com.kuit.findyou.domain.auth.service.ReissueTokenService;
+import com.kuit.findyou.domain.auth.service.AuthServiceFacade;
 import com.kuit.findyou.global.common.annotation.CustomExceptionDescription;
 import com.kuit.findyou.global.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,9 +27,7 @@ import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.
 @RequestMapping("api/v2/auth")
 @RestController
 public class AuthController {
-    // todo 퍼사드 패턴 도입
-    private final LoginService loginService;
-    private final ReissueTokenService reissueTokenService;
+    private final AuthServiceFacade authServiceFacade;
 
     @Operation(
             summary = "카카오 로그인 API",
@@ -40,7 +37,7 @@ public class AuthController {
     @CustomExceptionDescription(KAKAO_LOGIN)
     public BaseResponse<KakaoLoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request){
         log.info("[kakaoLogin] ");
-        return BaseResponse.ok(loginService.kakaoLogin(request));
+        return BaseResponse.ok(authServiceFacade.kakaoLogin(request));
     }
 
     @Operation(
@@ -51,12 +48,12 @@ public class AuthController {
     @CustomExceptionDescription(GUEST_LOGIN)
     public BaseResponse<GuestLoginResponse> guestLogin(@RequestBody GuestLoginRequest request){
         log.info("[guestLogin] deviceId = {}", request.deviceId());
-        return BaseResponse.ok(loginService.guestLogin(request));
+        return BaseResponse.ok(authServiceFacade.guestLogin(request));
     }
 
     @PostMapping("/reissue/token")
     public BaseResponse<ReissueTokenResponse> reissueToken(@RequestBody ReissueTokenRequest request){
         log.debug("[reissueToken] request.refreshToken = {}", request.refreshToken());
-        return BaseResponse.ok(reissueTokenService.reissueToken(request));
+        return BaseResponse.ok(authServiceFacade.reissueToken(request));
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -1,10 +1,13 @@
 package com.kuit.findyou.domain.auth.controller;
 
+import com.kuit.findyou.domain.auth.dto.ReissueTokenRequest;
+import com.kuit.findyou.domain.auth.dto.ReissueTokenResponse;
 import com.kuit.findyou.domain.auth.dto.request.GuestLoginRequest;
 import com.kuit.findyou.domain.auth.dto.response.GuestLoginResponse;
 import com.kuit.findyou.domain.auth.dto.request.KakaoLoginRequest;
 import com.kuit.findyou.domain.auth.dto.response.KakaoLoginResponse;
 import com.kuit.findyou.domain.auth.service.AuthService;
+import com.kuit.findyou.domain.auth.service.ReissueTokenService;
 import com.kuit.findyou.global.common.annotation.CustomExceptionDescription;
 import com.kuit.findyou.global.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,7 +28,9 @@ import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.
 @RequestMapping("api/v2/auth")
 @RestController
 public class AuthController {
+    // todo 퍼사드 패턴 도입
     private final AuthService authService;
+    private final ReissueTokenService reissueTokenService;
 
     @Operation(
             summary = "카카오 로그인 API",
@@ -34,7 +39,7 @@ public class AuthController {
     @PostMapping("/login/kakao")
     @CustomExceptionDescription(KAKAO_LOGIN)
     public BaseResponse<KakaoLoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request){
-        log.info("[kakaoLogin]");
+        log.info("[kakaoLogin] ");
         return BaseResponse.ok(authService.kakaoLogin(request));
     }
 
@@ -47,5 +52,11 @@ public class AuthController {
     public BaseResponse<GuestLoginResponse> guestLogin(@RequestBody GuestLoginRequest request){
         log.info("[guestLogin] deviceId = {}", request.deviceId());
         return BaseResponse.ok(authService.guestLogin(request));
+    }
+
+    @PostMapping("/reissue/token")
+    public BaseResponse<ReissueTokenResponse> reissueToken(@RequestBody ReissueTokenRequest request){
+        log.debug("[reissueToken] request.refreshToken = {}", request.refreshToken());
+        return BaseResponse.ok(reissueTokenService.reissueToken(request));
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -6,7 +6,7 @@ import com.kuit.findyou.domain.auth.dto.request.GuestLoginRequest;
 import com.kuit.findyou.domain.auth.dto.response.GuestLoginResponse;
 import com.kuit.findyou.domain.auth.dto.request.KakaoLoginRequest;
 import com.kuit.findyou.domain.auth.dto.response.KakaoLoginResponse;
-import com.kuit.findyou.domain.auth.service.AuthService;
+import com.kuit.findyou.domain.auth.service.LoginService;
 import com.kuit.findyou.domain.auth.service.ReissueTokenService;
 import com.kuit.findyou.global.common.annotation.CustomExceptionDescription;
 import com.kuit.findyou.global.common.response.BaseResponse;
@@ -29,7 +29,7 @@ import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.
 @RestController
 public class AuthController {
     // todo 퍼사드 패턴 도입
-    private final AuthService authService;
+    private final LoginService loginService;
     private final ReissueTokenService reissueTokenService;
 
     @Operation(
@@ -40,7 +40,7 @@ public class AuthController {
     @CustomExceptionDescription(KAKAO_LOGIN)
     public BaseResponse<KakaoLoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request){
         log.info("[kakaoLogin] ");
-        return BaseResponse.ok(authService.kakaoLogin(request));
+        return BaseResponse.ok(loginService.kakaoLogin(request));
     }
 
     @Operation(
@@ -51,7 +51,7 @@ public class AuthController {
     @CustomExceptionDescription(GUEST_LOGIN)
     public BaseResponse<GuestLoginResponse> guestLogin(@RequestBody GuestLoginRequest request){
         log.info("[guestLogin] deviceId = {}", request.deviceId());
-        return BaseResponse.ok(authService.guestLogin(request));
+        return BaseResponse.ok(loginService.guestLogin(request));
     }
 
     @PostMapping("/reissue/token")

--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -18,8 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.GUEST_LOGIN;
-import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.KAKAO_LOGIN;
+import static com.kuit.findyou.global.common.swagger.SwaggerResponseDescription.*;
 
 @Tag(name = "Login", description = "로그인 관련 API")
 @Slf4j
@@ -33,8 +32,8 @@ public class AuthController {
             summary = "카카오 로그인 API",
             description = "카카오 사용자 식별자를 이용해서 유저 정보와 엑세스 토큰을 얻을 수 있습니다. 가입된 회원인지 여부를 반환합니다."
     )
-    @PostMapping("/login/kakao")
     @CustomExceptionDescription(KAKAO_LOGIN)
+    @PostMapping("/login/kakao")
     public BaseResponse<KakaoLoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request){
         log.info("[kakaoLogin] ");
         return BaseResponse.ok(authServiceFacade.kakaoLogin(request));
@@ -44,13 +43,18 @@ public class AuthController {
             summary = "게스트 로그인 API",
             description = "디바이스id 식별자를 이용해서 유저 정보와 엑세스 토큰을 얻을 수 있습니다. 기존 게스트가 아니면 별도의 가입 API 호출 없이 정보가 자동으로 저장됩니다."
     )
-    @PostMapping("/login/guest")
     @CustomExceptionDescription(GUEST_LOGIN)
+    @PostMapping("/login/guest")
     public BaseResponse<GuestLoginResponse> guestLogin(@RequestBody GuestLoginRequest request){
         log.info("[guestLogin] deviceId = {}", request.deviceId());
         return BaseResponse.ok(authServiceFacade.guestLogin(request));
     }
 
+    @Operation(
+            summary = "토큰 재발급 API",
+            description = "만료되지 않은 리프레시 토큰으로 요청하면 새로운 엑세스 토큰과 리프레시 토큰을 얻을 수 있습니다."
+    )
+    @CustomExceptionDescription(REISSUE_TOKEN)
     @PostMapping("/reissue/token")
     public BaseResponse<ReissueTokenResponse> reissueToken(@RequestBody ReissueTokenRequest request){
         log.debug("[reissueToken] request.refreshToken = {}", request.refreshToken());

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/ReissueTokenRequest.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/ReissueTokenRequest.java
@@ -1,0 +1,6 @@
+package com.kuit.findyou.domain.auth.dto;
+
+public record ReissueTokenRequest(
+        String refreshToken
+) {
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/ReissueTokenResponse.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/ReissueTokenResponse.java
@@ -1,0 +1,7 @@
+package com.kuit.findyou.domain.auth.dto;
+
+public record ReissueTokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/response/GuestLoginResponse.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/response/GuestLoginResponse.java
@@ -7,6 +7,8 @@ public record GuestLoginResponse (
         @Schema(description = "유저 식별자")
         Long userId,
         @Schema(description = "엑세스 토큰")
-        String accessToken
+        String accessToken,
+        @Schema(description = "리프레시 토큰")
+        String refreshToken
 ){
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/dto/response/KakaoLoginResponse.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/response/KakaoLoginResponse.java
@@ -10,12 +10,12 @@ public record KakaoLoginResponse(
         @Schema(description = "첫 로그인 여부 = 회원가입 여부", example = "false")
         Boolean isFirstLogin
 ) {
-    public static KakaoLoginResponse fromUserAndAccessToken(User user, String accessToken) {
-        UserInfoDto userInfo = new UserInfoDto(user.getId(), user.getName(), accessToken);
+    public static KakaoLoginResponse fromUserAndTokens(User user, String accessToken, String refreshToken) {
+        UserInfoDto userInfo = new UserInfoDto(user.getId(), user.getName(), accessToken, refreshToken);
         return new KakaoLoginResponse(userInfo, false);
     }
 
-    public static KakaoLoginResponse notFound() {
+    public static KakaoLoginResponse firstLogin() {
         return new KakaoLoginResponse(null, true);
     }
 
@@ -25,7 +25,9 @@ public record KakaoLoginResponse(
             @Schema(description = "사용자 닉네임", example = "유저1")
             String nickname,
             @Schema(description = "찾아유 엑세스 토큰", example = "token1234token1234token1234")
-            String accessToken
+            String accessToken,
+            @Schema(description = "찾아유 리프레시 토큰", example = "token1234token1234token1234")
+            String refreshToken
     ) {
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepository.java
@@ -4,4 +4,6 @@ import java.util.Optional;
 
 public interface RedisRefreshTokenRepository {
     Optional<String> findByUserId(Long userId);
+
+    void save(Long id, String refreshToken);
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.kuit.findyou.domain.auth.repository;
+
+import java.util.Optional;
+
+public interface RedisRefreshTokenRepository {
+    Optional<String> findByUserId(Long userId);
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepositoryImpl.java
@@ -12,10 +12,9 @@ import java.util.Optional;
 @Repository
 public class RedisRefreshTokenRepositoryImpl implements RedisRefreshTokenRepository {
     private final RedisTemplate<String, String> redisTemplate;
+    private final String refreshTokenKeyPrefix = "refresh-token:";
     @Value("${findyou.jwt.expiration-ms.refresh-token}")
     private Long refreshTokenExpireMs;
-    @Value("${findyou.jwt.refresh-token-redis-key-prefix}")
-    private String refreshTokenKeyPrefix;
 
     private String key(Long userId) {
         return refreshTokenKeyPrefix + userId;

--- a/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepositoryImpl.java
@@ -20,4 +20,9 @@ public class RedisRefreshTokenRepositoryImpl implements RedisRefreshTokenReposit
         String value = redisTemplate.opsForValue().get(key(userId));
         return Optional.ofNullable(value);
     }
+
+    @Override
+    public void save(Long userId, String refreshToken) {
+        redisTemplate.opsForValue().set(key(userId), refreshToken);
+    }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepositoryImpl.java
@@ -1,18 +1,24 @@
 package com.kuit.findyou.domain.auth.repository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.time.Duration;
 import java.util.Optional;
 
 @RequiredArgsConstructor
 @Repository
 public class RedisRefreshTokenRepositoryImpl implements RedisRefreshTokenRepository {
     private final RedisTemplate<String, String> redisTemplate;
+    @Value("${findyou.jwt.expiration-ms.refresh-token}")
+    private Long refreshTokenExpireMs;
+    @Value("${findyou.jwt.refresh-token-redis-key-prefix}")
+    private String refreshTokenKeyPrefix;
 
     private String key(Long userId) {
-        return "refresh-token:" + userId;
+        return refreshTokenKeyPrefix + userId;
     }
 
     @Override
@@ -23,6 +29,6 @@ public class RedisRefreshTokenRepositoryImpl implements RedisRefreshTokenReposit
 
     @Override
     public void save(Long userId, String refreshToken) {
-        redisTemplate.opsForValue().set(key(userId), refreshToken);
+        redisTemplate.opsForValue().set(key(userId), refreshToken, Duration.ofMillis(refreshTokenExpireMs));
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepositoryImpl.java
@@ -1,15 +1,23 @@
 package com.kuit.findyou.domain.auth.repository;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@RequiredArgsConstructor
 @Repository
 public class RedisRefreshTokenRepositoryImpl implements RedisRefreshTokenRepository {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private String key(Long userId) {
+        return "refresh-token:" + userId;
+    }
 
     @Override
     public Optional<String> findByUserId(Long userId) {
-
-        return Optional.empty();
+        String value = redisTemplate.opsForValue().get(key(userId));
+        return Optional.ofNullable(value);
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/repository/RedisRefreshTokenRepositoryImpl.java
@@ -1,0 +1,15 @@
+package com.kuit.findyou.domain.auth.repository;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class RedisRefreshTokenRepositoryImpl implements RedisRefreshTokenRepository {
+
+    @Override
+    public Optional<String> findByUserId(Long userId) {
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/service/AuthServiceFacade.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/AuthServiceFacade.java
@@ -1,0 +1,29 @@
+package com.kuit.findyou.domain.auth.service;
+
+import com.kuit.findyou.domain.auth.dto.ReissueTokenRequest;
+import com.kuit.findyou.domain.auth.dto.ReissueTokenResponse;
+import com.kuit.findyou.domain.auth.dto.request.GuestLoginRequest;
+import com.kuit.findyou.domain.auth.dto.request.KakaoLoginRequest;
+import com.kuit.findyou.domain.auth.dto.response.GuestLoginResponse;
+import com.kuit.findyou.domain.auth.dto.response.KakaoLoginResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthServiceFacade {
+    private final LoginService loginService;
+    private final ReissueTokenService reissueTokenService;
+
+    public KakaoLoginResponse kakaoLogin(KakaoLoginRequest request) {
+        return loginService.kakaoLogin(request);
+    }
+
+    public GuestLoginResponse guestLogin(GuestLoginRequest request) {
+        return loginService.guestLogin(request);
+    }
+
+    public ReissueTokenResponse reissueToken(ReissueTokenRequest request) {
+        return reissueTokenService.reissueToken(request);
+    }
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/AuthServiceImpl.java
@@ -31,12 +31,16 @@ public class AuthServiceImpl implements AuthService {
         return userRepository.findByKakaoId(request.kakaoId())
                 .map(loginUser -> {
                     log.info("[kakaoLogin] user found");
-                    String token = jwtUtil.createAccessJwt(loginUser.getId(), loginUser.getRole());
-                    return KakaoLoginResponse.fromUserAndAccessToken(loginUser, token);
+                    String accessToken = jwtUtil.createAccessJwt(loginUser.getId(), loginUser.getRole());
+                    String refreshToken = jwtUtil.createRefreshJwt(loginUser.getId());
+
+                    redisRefreshTokenRepository.save(loginUser.getId(), refreshToken);
+
+                    return KakaoLoginResponse.fromUserAndTokens(loginUser, accessToken, refreshToken);
                 })
                 .orElseGet(() -> {
                     log.info("[kakaoLogin] user not found");
-                    return KakaoLoginResponse.notFound();
+                    return KakaoLoginResponse.firstLogin();
                 });
     }
 

--- a/src/main/java/com/kuit/findyou/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/AuthServiceImpl.java
@@ -4,6 +4,7 @@ import com.kuit.findyou.domain.auth.dto.request.GuestLoginRequest;
 import com.kuit.findyou.domain.auth.dto.response.GuestLoginResponse;
 import com.kuit.findyou.domain.auth.dto.request.KakaoLoginRequest;
 import com.kuit.findyou.domain.auth.dto.response.KakaoLoginResponse;
+import com.kuit.findyou.domain.auth.repository.RedisRefreshTokenRepository;
 import com.kuit.findyou.domain.user.constant.DefaultProfileImage;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
@@ -22,6 +23,7 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 @Service
 public class AuthServiceImpl implements AuthService {
     private final UserRepository userRepository;
+    private final RedisRefreshTokenRepository redisRefreshTokenRepository;
     private final JwtUtil jwtUtil;
     public KakaoLoginResponse kakaoLogin(KakaoLoginRequest request) {
         log.info("[kakaoLogin] kakaoId = {}", request.kakaoId());
@@ -60,8 +62,11 @@ public class AuthServiceImpl implements AuthService {
             throw new CustomException(GUEST_LOGIN_FAILED);
         }
 
-        // 응답 반환
+        // 토큰 생성
         String accessToken = jwtUtil.createAccessJwt(user.getId(), user.getRole());
-        return new GuestLoginResponse(user.getId(), accessToken);
+        String refreshToken = jwtUtil.createRefreshJwt(user.getId());
+        redisRefreshTokenRepository.save(user.getId(), refreshToken);
+
+        return new GuestLoginResponse(user.getId(), accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/service/LoginService.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/LoginService.java
@@ -5,7 +5,7 @@ import com.kuit.findyou.domain.auth.dto.response.GuestLoginResponse;
 import com.kuit.findyou.domain.auth.dto.request.KakaoLoginRequest;
 import com.kuit.findyou.domain.auth.dto.response.KakaoLoginResponse;
 
-public interface AuthService {
+public interface LoginService {
     KakaoLoginResponse kakaoLogin(KakaoLoginRequest request);
 
     GuestLoginResponse guestLogin(GuestLoginRequest request);

--- a/src/main/java/com/kuit/findyou/domain/auth/service/LoginServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/LoginServiceImpl.java
@@ -30,16 +30,14 @@ public class LoginServiceImpl implements LoginService {
 
         return userRepository.findByKakaoId(request.kakaoId())
                 .map(loginUser -> {
-                    log.info("[kakaoLogin] user found");
                     String accessToken = jwtUtil.createAccessJwt(loginUser.getId(), loginUser.getRole());
                     String refreshToken = jwtUtil.createRefreshJwt(loginUser.getId());
-
                     redisRefreshTokenRepository.save(loginUser.getId(), refreshToken);
-
+                    log.info("[kakaoLogin] 카카오 로그인 성공");
                     return KakaoLoginResponse.fromUserAndTokens(loginUser, accessToken, refreshToken);
                 })
                 .orElseGet(() -> {
-                    log.info("[kakaoLogin] user not found");
+                    log.info("[kakaoLogin] 일치하는 유저가 없어서 카카오 로그인 실패");
                     return KakaoLoginResponse.firstLogin();
                 });
     }
@@ -52,6 +50,7 @@ public class LoginServiceImpl implements LoginService {
         User user = userRepository.findByDeviceId(request.deviceId())
                 .orElseGet(()->{
                     // 디바이스 id에 해당하는 유저가 없으면 게스트 추가
+                    log.info("[guestLogin] 새로운 게스트 추가");
                     User build = User.builder()
                             .name("게스트")
                             .profileImageUrl(DefaultProfileImage.DEFAULT.getName())
@@ -63,6 +62,7 @@ public class LoginServiceImpl implements LoginService {
 
         // 게스트가 아니면 로그인 실패
         if(!user.isGuest()){
+            log.info("[guestLogin] 게스트 권한이 없어서 게스트 로그인 실패");
             throw new CustomException(GUEST_LOGIN_FAILED);
         }
 
@@ -70,7 +70,7 @@ public class LoginServiceImpl implements LoginService {
         String accessToken = jwtUtil.createAccessJwt(user.getId(), user.getRole());
         String refreshToken = jwtUtil.createRefreshJwt(user.getId());
         redisRefreshTokenRepository.save(user.getId(), refreshToken);
-
+        log.info("[guestLogin] 게스트 로그인 성공");
         return new GuestLoginResponse(user.getId(), accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/service/LoginServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/LoginServiceImpl.java
@@ -21,7 +21,7 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 @Slf4j
 @RequiredArgsConstructor
 @Service
-public class AuthServiceImpl implements AuthService {
+public class LoginServiceImpl implements LoginService {
     private final UserRepository userRepository;
     private final RedisRefreshTokenRepository redisRefreshTokenRepository;
     private final JwtUtil jwtUtil;

--- a/src/main/java/com/kuit/findyou/domain/auth/service/ReissueTokenService.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/ReissueTokenService.java
@@ -1,0 +1,8 @@
+package com.kuit.findyou.domain.auth.service;
+
+import com.kuit.findyou.domain.auth.dto.ReissueTokenRequest;
+import com.kuit.findyou.domain.auth.dto.ReissueTokenResponse;
+
+public interface ReissueTokenService {
+    ReissueTokenResponse reissueToken(ReissueTokenRequest request);
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImpl.java
@@ -29,16 +29,16 @@ public class ReissueTokenServiceImpl implements ReissueTokenService {
         }
         Long userId = jwtUtil.getUserId(request.refreshToken());
 
-        // 리프레시 토큰 찾기
-        // 없으면 에러
+        // 저장된 리프레시 토큰이 없으면 에러
         String foundRefreshToken = redisRefreshTokenRepository.findByUserId(userId)
                 .orElseThrow(() -> new CustomException(REFRESH_TOKEN_NOT_FOUND));
 
-        // 토큰이 일치하면 토큰 재발급
+        // 토큰이 일차히자 않으면 에러
         if(!foundRefreshToken.equals(request.refreshToken())){
             throw new CustomException(REFRESH_TOKEN_NOT_FOUND);
         }
 
+        // 토큰이 일치하면 토큰 재발급
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         String accessToken = jwtUtil.createAccessJwt(user.getId(), user.getRole());

--- a/src/main/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImpl.java
@@ -30,10 +30,14 @@ public class ReissueTokenServiceImpl implements ReissueTokenService {
 
         // 저장된 리프레시 토큰이 없으면 에러
         String foundRefreshToken = redisRefreshTokenRepository.findByUserId(userId)
-                .orElseThrow(() -> new CustomException(REFRESH_TOKEN_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.info("[reissueToken] 토큰이 존재하지 않음");
+                    return new CustomException(REFRESH_TOKEN_NOT_FOUND);
+                });
 
         // 토큰이 일차히지 않으면 에러
         if(!foundRefreshToken.equals(request.refreshToken())){
+            log.info("[reissueToken] 토큰이 일치하지 않음");
             throw new CustomException(REFRESH_TOKEN_NOT_FOUND);
         }
 
@@ -43,6 +47,9 @@ public class ReissueTokenServiceImpl implements ReissueTokenService {
         String accessToken = jwtUtil.createAccessJwt(user.getId(), user.getRole());
         String refreshToken = jwtUtil.createRefreshJwt(user.getId());
 
+        redisRefreshTokenRepository.save(user.getId(), refreshToken);
+
+        log.info("[reissueToken] 토큰 재발급 완료");
         return new ReissueTokenResponse(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImpl.java
@@ -1,0 +1,49 @@
+package com.kuit.findyou.domain.auth.service;
+
+import com.kuit.findyou.domain.auth.dto.ReissueTokenRequest;
+import com.kuit.findyou.domain.auth.dto.ReissueTokenResponse;
+import com.kuit.findyou.domain.auth.repository.RedisRefreshTokenRepository;
+import com.kuit.findyou.domain.user.model.User;
+import com.kuit.findyou.domain.user.repository.UserRepository;
+import com.kuit.findyou.global.common.exception.CustomException;
+import com.kuit.findyou.global.jwt.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ReissueTokenServiceImpl implements ReissueTokenService {
+    private final JwtUtil jwtUtil;
+    private final RedisRefreshTokenRepository redisRefreshTokenRepository;
+    private final UserRepository userRepository;
+    @Override
+    public ReissueTokenResponse reissueToken(ReissueTokenRequest request) {
+        log.info("[reissueToken] 토큰 재발급 시작");
+        // 리프레시 토큰 만료 여부 검증
+        if(jwtUtil.isExpired(request.refreshToken())){
+            throw new CustomException(EXPIRED_JWT);
+        }
+        Long userId = jwtUtil.getUserId(request.refreshToken());
+
+        // 리프레시 토큰 찾기
+        // 없으면 에러
+        String foundRefreshToken = redisRefreshTokenRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(REFRESH_TOKEN_NOT_FOUND));
+
+        // 토큰이 일치하면 토큰 재발급
+        if(!foundRefreshToken.equals(request.refreshToken())){
+            throw new CustomException(REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        String accessToken = jwtUtil.createAccessJwt(user.getId(), user.getRole());
+        String refreshToken = jwtUtil.createRefreshJwt(user.getId());
+
+        return new ReissueTokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImpl.java
@@ -23,17 +23,16 @@ public class ReissueTokenServiceImpl implements ReissueTokenService {
     @Override
     public ReissueTokenResponse reissueToken(ReissueTokenRequest request) {
         log.info("[reissueToken] 토큰 재발급 시작");
-        // 리프레시 토큰 만료 여부 검증
-        if(jwtUtil.isExpired(request.refreshToken())){
-            throw new CustomException(EXPIRED_JWT);
-        }
+        // 리프레시 토큰 검증
+        jwtUtil.validateJwt(request.refreshToken());
+
         Long userId = jwtUtil.getUserId(request.refreshToken());
 
         // 저장된 리프레시 토큰이 없으면 에러
         String foundRefreshToken = redisRefreshTokenRepository.findByUserId(userId)
                 .orElseThrow(() -> new CustomException(REFRESH_TOKEN_NOT_FOUND));
 
-        // 토큰이 일차히자 않으면 에러
+        // 토큰이 일차히지 않으면 에러
         if(!foundRefreshToken.equals(request.refreshToken())){
             throw new CustomException(REFRESH_TOKEN_NOT_FOUND);
         }

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -35,6 +35,9 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     // 홈
     HOME_STATISTICS_UPDATE_FAILED(502, "홈화면 통계 업데이트에 실패했습니다."),
 
+    // 인증인가 - Auth
+    REFRESH_TOKEN_NOT_FOUND(404, "일치하는 리프레시 토큰이 없습니다"),
+
     // 유저 - User
     USER_NOT_FOUND(404, "존재하지 않는 유저입니다."),
     DUPLICATE_INTEREST_REPORT(400, "이미 관심글로 등록된 신고글입니다."),

--- a/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/kuit/findyou/global/common/swagger/SwaggerResponseDescription.java
@@ -30,6 +30,14 @@ public enum SwaggerResponseDescription {
             GUEST_LOGIN_FAILED
     ))),
 
+    REISSUE_TOKEN(new LinkedHashSet<>(Set.of(
+            INVALID_JWT,
+            EXPIRED_JWT,
+            JWT_NOT_FOUND,
+            REFRESH_TOKEN_NOT_FOUND,
+            USER_NOT_FOUND
+    ))),
+
     KAKAO_LOGIN(new LinkedHashSet<>(Set.of())),
 
     TEST(new LinkedHashSet<>(Set.of(

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
@@ -24,8 +24,11 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 public class JwtUtil {
     private final SecretKey secretKey;
 
-    @Value("${findyou.jwt.access.expire-ms}")
+    @Value("${findyou.jwt.expiration-ms.access-token}")
     private long accessTokenExpireMs;
+
+    @Value("${findyou.jwt.expiration-ms.refresh-token}")
+    private long refreshTokenExpireMs;
 
     public JwtUtil(@Value("${findyou.jwt.secret-key}") String secret) {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
@@ -57,6 +60,16 @@ public class JwtUtil {
                 .compact();
     }
 
+    public String createRefreshJwt(Long userId) {
+        return Jwts.builder()
+                .claim(JwtClaimKey.USER_ID.getKey(), userId)
+                .claim(JwtClaimKey.TOKEN_TYPE.getKey(), JwtTokenType.REFRESH_TOKEN)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpireMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
     public void validateJwt(String token){
         log.info("validateJwt");
         try{
@@ -70,5 +83,15 @@ public class JwtUtil {
         } catch (IllegalArgumentException e) {
             throw new JwtNotFoundException(JWT_NOT_FOUND);
         }
+    }
+
+    public boolean isExpired(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration()
+                .before(new Date());
     }
 }

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
@@ -84,14 +84,4 @@ public class JwtUtil {
             throw new JwtNotFoundException(JWT_NOT_FOUND);
         }
     }
-
-    public boolean isExpired(String token) {
-        return Jwts.parser()
-                .verifyWith(secretKey)
-                .build()
-                .parseSignedClaims(token)
-                .getPayload()
-                .getExpiration()
-                .before(new Date());
-    }
 }

--- a/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
+++ b/src/main/java/com/kuit/findyou/global/jwt/util/JwtUtil.java
@@ -16,6 +16,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.UUID;
 
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
 
@@ -62,6 +63,7 @@ public class JwtUtil {
 
     public String createRefreshJwt(Long userId) {
         return Jwts.builder()
+                .id(UUID.randomUUID().toString())
                 .claim(JwtClaimKey.USER_ID.getKey(), userId)
                 .claim(JwtClaimKey.TOKEN_TYPE.getKey(), JwtTokenType.REFRESH_TOKEN)
                 .issuedAt(new Date(System.currentTimeMillis()))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
       local : local-db, dev-port, common
       dev: dev-db, dev-port, common
       prod: prod-db, prod-port, common
-    active: prod
+    active: local
   web:
     resources:
       add-mappings: false
@@ -157,6 +157,7 @@ findyou:
       access-token : ${JWT_ACCESS_EXPIRE_MS}
       refresh-token : ${JWT_REFRESH_EXPIRE_MS}
     secret-key : ${JWT_SECRET_KEY}
+    refresh-token-redis-key-prefix: ${JWT_REFRESH_REDIS_KEY_PREFIX}
   home-stats:
     parsing-timeout-sec: ${HOME_STATS_PARSING_TIMEOUT_SEC}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -157,7 +157,6 @@ findyou:
       access-token : ${JWT_ACCESS_EXPIRE_MS}
       refresh-token : ${JWT_REFRESH_EXPIRE_MS}
     secret-key : ${JWT_SECRET_KEY}
-    refresh-token-redis-key-prefix: ${JWT_REFRESH_REDIS_KEY_PREFIX}
   home-stats:
     parsing-timeout-sec: ${HOME_STATS_PARSING_TIMEOUT_SEC}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -153,8 +153,9 @@ logging:
 
 findyou:
   jwt:
-    access:
-      expire-ms: ${JWT_ACCESS_EXPIRE_MS}
+    expiration-ms:
+      access-token : ${JWT_ACCESS_EXPIRE_MS}
+      refresh-token : ${JWT_REFRESH_EXPIRE_MS}
     secret-key : ${JWT_SECRET_KEY}
   home-stats:
     parsing-timeout-sec: ${HOME_STATS_PARSING_TIMEOUT_SEC}

--- a/src/test/java/com/kuit/findyou/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/controller/AuthControllerTest.java
@@ -232,7 +232,7 @@ class AuthControllerTest {
     @DisplayName("리프레시 토큰이 일치하지 않으면 404 코드를 응답한다")
     @Test
     void reissueToken_shouldReturnNotFound_WhenRefreshTokenIsNotMatched(){
-// given
+        // given
         User user = createUser("회원", Role.USER, null, "asdf-1234-asdf");
         String unknownRefreshToken = jwtUtil.createRefreshJwt(user.getId());
         String savedRefreshToken = jwtUtil.createRefreshJwt(user.getId());

--- a/src/test/java/com/kuit/findyou/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/controller/AuthControllerTest.java
@@ -13,6 +13,7 @@ import com.kuit.findyou.domain.user.repository.UserRepository;
 import com.kuit.findyou.global.common.response.BaseErrorResponse;
 import com.kuit.findyou.global.common.response.BaseResponse;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
+import com.kuit.findyou.global.config.RedisTestContainersConfig;
 import com.kuit.findyou.global.config.TestDatabaseConfig;
 import com.kuit.findyou.global.jwt.util.JwtClaimKey;
 import com.kuit.findyou.global.jwt.util.JwtTokenType;
@@ -42,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
-@Import(TestDatabaseConfig.class)
+@Import({RedisTestContainersConfig.class, TestDatabaseConfig.class})
 class AuthControllerTest {
     @LocalServerPort
     int port;

--- a/src/test/java/com/kuit/findyou/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/controller/AuthControllerTest.java
@@ -1,9 +1,12 @@
 package com.kuit.findyou.domain.auth.controller;
 
+import com.kuit.findyou.domain.auth.dto.ReissueTokenRequest;
+import com.kuit.findyou.domain.auth.dto.ReissueTokenResponse;
 import com.kuit.findyou.domain.auth.dto.request.GuestLoginRequest;
 import com.kuit.findyou.domain.auth.dto.response.GuestLoginResponse;
 import com.kuit.findyou.domain.auth.dto.request.KakaoLoginRequest;
 import com.kuit.findyou.domain.auth.dto.response.KakaoLoginResponse;
+import com.kuit.findyou.domain.auth.repository.RedisRefreshTokenRepository;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
@@ -11,19 +14,28 @@ import com.kuit.findyou.global.common.response.BaseErrorResponse;
 import com.kuit.findyou.global.common.response.BaseResponse;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
 import com.kuit.findyou.global.config.TestDatabaseConfig;
+import com.kuit.findyou.global.jwt.util.JwtClaimKey;
 import com.kuit.findyou.global.jwt.util.JwtTokenType;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
+import io.jsonwebtoken.Jwts;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
-import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.GUEST_LOGIN_FAILED;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,10 +51,16 @@ class AuthControllerTest {
     private UserRepository userRepository;
 
     @Autowired
+    private RedisRefreshTokenRepository redisRefreshTokenRepository;
+
+    @Autowired
     private JwtUtil jwtUtil;
 
     @Autowired
     private DatabaseCleaner databaseCleaner;
+
+    @Value("${findyou.jwt.secret-key}") 
+    String secret;
 
     @BeforeEach
     void setUp() {
@@ -53,7 +71,7 @@ class AuthControllerTest {
 
     @DisplayName("기존 회원이 로그인하면 유저 정보를 반환한다")
     @Test
-    void should_ReturnUserInfo_When_ExistingUserLogsIn(){
+    void kakaoLogin_shouldReturnUserInfo_WhenAlreadyRegisteredUser(){
         // given
         final String NAME = "유저";
         final Role ROLE = Role.USER;
@@ -98,7 +116,7 @@ class AuthControllerTest {
 
     @DisplayName("게스트가 로그인하면 성공한다.")
     @Test
-    void should_Succeed_When_GuestLogsIn(){
+    void guestLogin_shouldSucceed_WhenAlreadyRegisteredGuest(){
         // given
         final String deviceId = "asdf-1234-asdf";
 
@@ -122,9 +140,10 @@ class AuthControllerTest {
         assertThat(jwtUtil.getUserId(response.accessToken())).isEqualTo(user.getId());
         assertThat(jwtUtil.getRole(response.accessToken())).isEqualTo(user.getRole());
     }
+
     @DisplayName("게스트가 아닌 유저가 로그인하면 실패한다.")
     @Test
-    void should_Fail_When_NonGuestUserLogsIn(){
+    void guestLogin_shouldFail_WhenUnknownUser(){
         // given
         final String deviceId = "asdf-1234-asdf";
 
@@ -138,13 +157,101 @@ class AuthControllerTest {
                 .when()
                 .post("/api/v2/auth/login/guest")
                 .then()
-                .statusCode(200)
                 .extract()
-                .as(new TypeRef<BaseErrorResponse>() {});
+                .as(new TypeRef<BaseErrorResponse>() { });
 
         // then
         assertThat(response.getCode()).isEqualTo(GUEST_LOGIN_FAILED.getCode());
         assertThat(response.getMessage()).isEqualTo(GUEST_LOGIN_FAILED.getMessage());
         assertThat(response.getSuccess()).isFalse();
+    }
+
+    @DisplayName("올바른 리프레시 토큰으로 요청하면 200 코드를 응답한다")
+    @Test
+    void reissueToken_shouldReturnSuccess_WhenValidRefreshToken(){
+        // given
+        User user = createUser("회원", Role.USER, null, "asdf-1234-asdf");
+        String refreshToken = jwtUtil.createRefreshJwt(user.getId());
+        redisRefreshTokenRepository.save(user.getId(), refreshToken);
+
+        // when
+        ReissueTokenResponse response = given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(new ReissueTokenRequest(refreshToken))
+                .when()
+                .post("/api/v2/auth/reissue/token")
+                .then()
+                .extract()
+                .jsonPath()
+                .getObject("data", ReissueTokenResponse.class);
+
+        // then
+        assertThat(response.accessToken()).isNotBlank();
+        assertThat(response.refreshToken()).isNotBlank();
+    }
+
+    @DisplayName("리프레시 토큰이 만료되었으면 401 코드를 응답한다")
+    @Test
+    void reissueToken_shouldReturnUnauthorized_WhenRefreshTokenIsNotMatched(){
+        // given
+        User user = createUser("회원", Role.USER, null, "asdf-1234-asdf");
+        String expiredRefreshToken = createExpiredRefreshJwt(user.getId());
+
+        // when
+        BaseErrorResponse response = given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(new ReissueTokenRequest(expiredRefreshToken))
+                .when()
+                .post("/api/v2/auth/reissue/token")
+                .then()
+                .log().all()
+                .extract()
+                .as(new TypeRef<BaseErrorResponse>() {
+                });
+
+        // then
+        assertThat(response.getCode()).isEqualTo(EXPIRED_JWT.getCode());
+        assertThat(response.getMessage()).isEqualTo(EXPIRED_JWT.getMessage());
+    }
+
+    private String createExpiredRefreshJwt(Long userId) {
+        SecretKey secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+        return Jwts.builder()
+                .id(UUID.randomUUID().toString())
+                .claim(JwtClaimKey.USER_ID.getKey(), userId)
+                .claim(JwtClaimKey.TOKEN_TYPE.getKey(), JwtTokenType.REFRESH_TOKEN)
+                .issuedAt(new Date(System.currentTimeMillis() - 100))
+                .expiration(new Date(System.currentTimeMillis()))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    @DisplayName("리프레시 토큰이 일치하지 않으면 404 코드를 응답한다")
+    @Test
+    void reissueToken_shouldReturnNotFound_WhenRefreshTokenIsNotMatched(){
+// given
+        User user = createUser("회원", Role.USER, null, "asdf-1234-asdf");
+        String unknownRefreshToken = jwtUtil.createRefreshJwt(user.getId());
+        String savedRefreshToken = jwtUtil.createRefreshJwt(user.getId());
+        redisRefreshTokenRepository.save(user.getId(), savedRefreshToken);
+
+        // when
+        BaseErrorResponse response = given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(new ReissueTokenRequest(unknownRefreshToken))
+                .when()
+                .post("/api/v2/auth/reissue/token")
+                .then()
+                .log().all()
+                .extract()
+                .as(new TypeRef<BaseErrorResponse>() {
+                });
+
+        // then
+        assertThat(response.getCode()).isEqualTo(REFRESH_TOKEN_NOT_FOUND.getCode());
+        assertThat(response.getMessage()).isEqualTo(REFRESH_TOKEN_NOT_FOUND.getMessage());
     }
 }

--- a/src/test/java/com/kuit/findyou/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import com.kuit.findyou.domain.auth.dto.request.GuestLoginRequest;
 import com.kuit.findyou.domain.auth.dto.response.GuestLoginResponse;
 import com.kuit.findyou.domain.auth.dto.request.KakaoLoginRequest;
 import com.kuit.findyou.domain.auth.dto.response.KakaoLoginResponse;
+import com.kuit.findyou.domain.auth.repository.RedisRefreshTokenRepository;
 import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
@@ -32,8 +33,11 @@ class AuthServiceTest {
     @Mock
     private UserRepository userRepository;
     @Mock
+    private RedisRefreshTokenRepository redisRefreshTokenRepository;
+    @Mock
     private JwtUtil jwtUtil;
 
+    @DisplayName("카카오 id와 일치하는 사용자가 없다면 isFirstLogin을 true로 반환하여 회원가입을 유도한다")
     @Test
     void should_ReturnfirstLoginWithTrue_When_UserWithKakaoIdNotFound(){
         // given
@@ -48,21 +52,26 @@ class AuthServiceTest {
         assertThat(response.userInfo()).isNull();
     }
 
+    @DisplayName("카카오 id와 일치하는 사용자가 있다면 정보를 리턴한다")
     @Test
     void should_ReturnUserInfo_When_UserWithKakaoIdExists(){
         // given
         final Long KAKAO_ID = 1234L;
         final String ACCESS_TOKEN = "accessToken";
+        final String REFRESH_TOKEN = "accessToken";
         final String NAME = "유저";
 
         User user = mockUser(NAME, Role.USER, KAKAO_ID);
         when(userRepository.findByKakaoId(KAKAO_ID)).thenReturn(Optional.of(user));
         when(jwtUtil.createAccessJwt(user.getId(), user.getRole())).thenReturn(ACCESS_TOKEN);
+        when(jwtUtil.createRefreshJwt(user.getId())).thenReturn(REFRESH_TOKEN);
 
         // when
         KakaoLoginResponse response = authService.kakaoLogin(new KakaoLoginRequest(KAKAO_ID));
 
         // then
+        verify(redisRefreshTokenRepository, times(1)).save(anyLong(), anyString());
+
         assertThat(response.isFirstLogin()).isFalse();
         assertThat(response.userInfo()).isNotNull();
         assertThat(response.userInfo().userId()).isEqualTo(user.getId());
@@ -87,18 +96,23 @@ class AuthServiceTest {
         // given
         final String deviceId = "asdf-1234-asdf";
         final String accessToken = "accessToken";
+        final String refreshToken = "refreshToken";
 
         User user = mockUser("게스트", Role.GUEST, null);
         when(userRepository.findByDeviceId(eq(deviceId))).thenReturn(Optional.of(user));
-        when(jwtUtil.createAccessJwt(user.getId(), user.getRole())).thenReturn(accessToken);
+        when(jwtUtil.createAccessJwt(anyLong(), any(Role.class))).thenReturn(accessToken);
+        when(jwtUtil.createRefreshJwt(anyLong())).thenReturn(refreshToken);
 
         // when
         GuestLoginResponse response = authService.guestLogin(new GuestLoginRequest(deviceId));
 
         // then
         verify(userRepository, never()).save(any());
+        verify(redisRefreshTokenRepository, times(1)).save(anyLong(), anyString());
+
         assertThat(response.userId()).isEqualTo(user.getId());
         assertThat(response.accessToken()).isEqualTo(accessToken);
+        assertThat(response.refreshToken()).isEqualTo(refreshToken);
     }
 
     @DisplayName("디바이스 id가 일치하는 유저가 없으면 새로 게스트를 저장한다")
@@ -107,19 +121,24 @@ class AuthServiceTest {
         // given
         final String deviceId = "asdf-1234-asdf";
         final String accessToken = "accessToken";
+        final String refreshToken = "refreshToken";
 
         User user = mockUser("게스트", Role.GUEST, null);
         when(userRepository.findByDeviceId(eq(deviceId))).thenReturn(Optional.empty());
         when(userRepository.save(any())).thenReturn(user);
-        when(jwtUtil.createAccessJwt(user.getId(), user.getRole())).thenReturn(accessToken);
+        when(jwtUtil.createAccessJwt(anyLong(), any(Role.class))).thenReturn(accessToken);
+        when(jwtUtil.createRefreshJwt(anyLong())).thenReturn(refreshToken);
 
         // when
         GuestLoginResponse response = authService.guestLogin(new GuestLoginRequest(deviceId));
 
         // then
         verify(userRepository).save(any(User.class));
+        verify(redisRefreshTokenRepository, times(1)).save(anyLong(), anyString());
+
         assertThat(response.userId()).isEqualTo(user.getId());
         assertThat(response.accessToken()).isEqualTo(accessToken);
+        assertThat(response.refreshToken()).isEqualTo(refreshToken);
     }
 
     @DisplayName("게스트가 아니면 예외가 발생한다.")

--- a/src/test/java/com/kuit/findyou/domain/auth/service/LoginServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/service/LoginServiceTest.java
@@ -76,6 +76,7 @@ class LoginServiceTest {
         assertThat(response.userInfo()).isNotNull();
         assertThat(response.userInfo().userId()).isEqualTo(user.getId());
         assertThat(response.userInfo().accessToken()).isEqualTo(ACCESS_TOKEN);
+        assertThat(response.userInfo().refreshToken()).isEqualTo(REFRESH_TOKEN);
         assertThat(response.userInfo().nickname()).isEqualTo(NAME);
     }
 

--- a/src/test/java/com/kuit/findyou/domain/auth/service/LoginServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/service/LoginServiceTest.java
@@ -27,9 +27,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class AuthServiceTest {
+class LoginServiceTest {
     @InjectMocks
-    private AuthServiceImpl authService;
+    private LoginServiceImpl authService;
     @Mock
     private UserRepository userRepository;
     @Mock

--- a/src/test/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImplTest.java
@@ -76,11 +76,11 @@ class ReissueTokenServiceImplTest {
         doThrow(new JwtExpiredException(EXPIRED_JWT)).when(jwtUtil).validateJwt(anyString());
 
         // when & then
-        verify(redisRefreshTokenRepository, never()).save(anyLong(), anyString());
-
         assertThatThrownBy(() -> reissueTokenService.reissueToken(request))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(EXPIRED_JWT.getMessage());
+
+        verify(redisRefreshTokenRepository, never()).save(anyLong(), anyString());
     }
 
     @DisplayName("리프레시 토큰이 저장된 리프레시 토큰과 일치하지 않으면 예외를 발생시킨다")
@@ -95,11 +95,12 @@ class ReissueTokenServiceImplTest {
         when(redisRefreshTokenRepository.findByUserId(any(Long.class))).thenReturn(Optional.of("valid refresh"));
 
         // when & then
-        verify(redisRefreshTokenRepository, never()).save(anyLong(), anyString());
-
         assertThatThrownBy(() -> reissueTokenService.reissueToken(request))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(REFRESH_TOKEN_NOT_FOUND.getMessage());
+
+        verify(redisRefreshTokenRepository, never()).save(anyLong(), anyString());
+
     }
 
     @DisplayName("저장된 리프레시 토큰이 없으면 예외를 발생시킨다")
@@ -114,10 +115,10 @@ class ReissueTokenServiceImplTest {
         when(redisRefreshTokenRepository.findByUserId(any(Long.class))).thenReturn(Optional.empty());
 
         // when & then
-        verify(redisRefreshTokenRepository, never()).save(anyLong(), anyString());
-
         assertThatThrownBy(() -> reissueTokenService.reissueToken(request))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(REFRESH_TOKEN_NOT_FOUND.getMessage());
+
+        verify(redisRefreshTokenRepository, never()).save(anyLong(), anyString());
     }
 }

--- a/src/test/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImplTest.java
@@ -101,4 +101,23 @@ class ReissueTokenServiceImplTest {
                 .isInstanceOf(CustomException.class)
                 .hasMessage(REFRESH_TOKEN_NOT_FOUND.getMessage());
     }
+
+    @DisplayName("저장된 리프레시 토큰이 없으면 예외를 발생시킨다")
+    @Test
+    void reissueToken_shouldThrowException_whenNoSavedRefreshToken(){
+        // given
+        Long userId = 1L;
+
+        ReissueTokenRequest request = new ReissueTokenRequest("refresh");
+
+        when(jwtUtil.getUserId(any(String.class))).thenReturn(userId);
+        when(redisRefreshTokenRepository.findByUserId(any(Long.class))).thenReturn(Optional.empty());
+
+        // when & then
+        verify(redisRefreshTokenRepository, never()).save(anyLong(), anyString());
+
+        assertThatThrownBy(() -> reissueTokenService.reissueToken(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(REFRESH_TOKEN_NOT_FOUND.getMessage());
+    }
 }

--- a/src/test/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImplTest.java
@@ -7,6 +7,7 @@ import com.kuit.findyou.domain.user.model.Role;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
 import com.kuit.findyou.global.common.exception.CustomException;
+import com.kuit.findyou.global.jwt.exception.JwtExpiredException;
 import com.kuit.findyou.global.jwt.util.JwtUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,6 @@ class ReissueTokenServiceImplTest {
 
         ReissueTokenRequest request = new ReissueTokenRequest(existingRefreshToken);
 
-        when(jwtUtil.isExpired(any(String.class))).thenReturn(false);
         when(jwtUtil.getUserId(any(String.class))).thenReturn(userId);
         when(redisRefreshTokenRepository.findByUserId(any(Long.class))).thenReturn(Optional.of(existingRefreshToken));
         when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(user));
@@ -70,7 +70,8 @@ class ReissueTokenServiceImplTest {
     void reissueToken_shouldThrowException_whenInvalidRefreshToken(){
         // given
         ReissueTokenRequest request = new ReissueTokenRequest("expired refresh");
-        when(jwtUtil.isExpired(any(String.class))).thenReturn(true);
+
+        doThrow(new JwtExpiredException(EXPIRED_JWT)).when(jwtUtil).validateJwt(anyString());
 
         // when & then
         assertThatThrownBy(() -> reissueTokenService.reissueToken(request))
@@ -86,7 +87,6 @@ class ReissueTokenServiceImplTest {
 
         ReissueTokenRequest request = new ReissueTokenRequest("old refresh");
 
-        when(jwtUtil.isExpired(any(String.class))).thenReturn(false);
         when(jwtUtil.getUserId(any(String.class))).thenReturn(userId);
         when(redisRefreshTokenRepository.findByUserId(any(Long.class))).thenReturn(Optional.of("valid refresh"));
 

--- a/src/test/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImplTest.java
@@ -61,6 +61,8 @@ class ReissueTokenServiceImplTest {
         ReissueTokenResponse response = reissueTokenService.reissueToken(request);
 
         // then
+        verify(redisRefreshTokenRepository, times(1)).save(anyLong(), anyString());
+
         assertThat(response.accessToken()).isEqualTo(newAccessToken);
         assertThat(response.refreshToken()).isEqualTo(newRefreshToken);
     }
@@ -74,6 +76,8 @@ class ReissueTokenServiceImplTest {
         doThrow(new JwtExpiredException(EXPIRED_JWT)).when(jwtUtil).validateJwt(anyString());
 
         // when & then
+        verify(redisRefreshTokenRepository, never()).save(anyLong(), anyString());
+
         assertThatThrownBy(() -> reissueTokenService.reissueToken(request))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(EXPIRED_JWT.getMessage());
@@ -91,6 +95,8 @@ class ReissueTokenServiceImplTest {
         when(redisRefreshTokenRepository.findByUserId(any(Long.class))).thenReturn(Optional.of("valid refresh"));
 
         // when & then
+        verify(redisRefreshTokenRepository, never()).save(anyLong(), anyString());
+
         assertThatThrownBy(() -> reissueTokenService.reissueToken(request))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(REFRESH_TOKEN_NOT_FOUND.getMessage());

--- a/src/test/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/auth/service/ReissueTokenServiceImplTest.java
@@ -1,0 +1,98 @@
+package com.kuit.findyou.domain.auth.service;
+
+import com.kuit.findyou.domain.auth.dto.ReissueTokenRequest;
+import com.kuit.findyou.domain.auth.dto.ReissueTokenResponse;
+import com.kuit.findyou.domain.auth.repository.RedisRefreshTokenRepository;
+import com.kuit.findyou.domain.user.model.Role;
+import com.kuit.findyou.domain.user.model.User;
+import com.kuit.findyou.domain.user.repository.UserRepository;
+import com.kuit.findyou.global.common.exception.CustomException;
+import com.kuit.findyou.global.jwt.util.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.EXPIRED_JWT;
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.REFRESH_TOKEN_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReissueTokenServiceImplTest {
+    @InjectMocks
+    ReissueTokenServiceImpl reissueTokenService;
+
+    @Mock
+    JwtUtil jwtUtil;
+
+    @Mock
+    RedisRefreshTokenRepository redisRefreshTokenRepository;
+
+    @Mock
+    UserRepository userRepository;
+
+    @DisplayName("올바른 리프레시 토큰이면 토큰을 반환한다")
+    @Test
+    void reissueToken_shouldReturnToken_whenValidRefreshToken(){
+        // given
+        Long userId = 1L;
+        String existingRefreshToken = "valid refresh";
+        String newAccessToken = "new access";
+        String newRefreshToken = "new refresh";
+        User user = User.builder().id(userId).role(Role.USER).build();
+
+        ReissueTokenRequest request = new ReissueTokenRequest(existingRefreshToken);
+
+        when(jwtUtil.isExpired(any(String.class))).thenReturn(false);
+        when(jwtUtil.getUserId(any(String.class))).thenReturn(userId);
+        when(redisRefreshTokenRepository.findByUserId(any(Long.class))).thenReturn(Optional.of(existingRefreshToken));
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(user));
+        when(jwtUtil.createAccessJwt(any(Long.class), any(Role.class))).thenReturn(newAccessToken);
+        when(jwtUtil.createRefreshJwt(any(Long.class))).thenReturn(newRefreshToken);
+
+        // when
+        ReissueTokenResponse response = reissueTokenService.reissueToken(request);
+
+        // then
+        assertThat(response.accessToken()).isEqualTo(newAccessToken);
+        assertThat(response.refreshToken()).isEqualTo(newRefreshToken);
+    }
+
+    @DisplayName("만료된 리프레시 토큰이면 예외를 발생시킨다")
+    @Test
+    void reissueToken_shouldThrowException_whenInvalidRefreshToken(){
+        // given
+        ReissueTokenRequest request = new ReissueTokenRequest("expired refresh");
+        when(jwtUtil.isExpired(any(String.class))).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> reissueTokenService.reissueToken(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(EXPIRED_JWT.getMessage());
+    }
+
+    @DisplayName("리프레시 토큰이 저장된 리프레시 토큰과 일치하지 않으면 예외를 발생시킨다")
+    @Test
+    void reissueToken_shouldThrowException_whenRefreshTokenIsNotMatched(){
+        // given
+        Long userId = 1L;
+
+        ReissueTokenRequest request = new ReissueTokenRequest("old refresh");
+
+        when(jwtUtil.isExpired(any(String.class))).thenReturn(false);
+        when(jwtUtil.getUserId(any(String.class))).thenReturn(userId);
+        when(redisRefreshTokenRepository.findByUserId(any(Long.class))).thenReturn(Optional.of("valid refresh"));
+
+        // when & then
+        assertThatThrownBy(() -> reissueTokenService.reissueToken(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(REFRESH_TOKEN_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,6 +32,7 @@ findyou:
       access-token : 6000000
       refresh-token : 6000000
     secret-key : secretkey1224secretkey1224secretkey1224secretkey1224
+    refresh-token-redis-key-prefix: "refresh-token-redis-key-prefix:"
   home-stats:
     parsing-timeout-sec: 20
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -28,8 +28,9 @@ spring:
 
 findyou:
   jwt:
-    access:
-      expire-ms: 6000000
+    expiration-ms:
+      access-token : 6000000
+      refresh-token : 6000000
     secret-key : secretkey1224secretkey1224secretkey1224secretkey1224
   home-stats:
     parsing-timeout-sec: 20


### PR DESCRIPTION
## Related issue 🛠
- closed #148

## Work Description 📝
- 토큰 재발급 API를 구현했습니다. 
  - 만료되지 않은 리프레시 토큰을 요청에 첨부하면, 새로운 엑세스 토큰과 리프레시 토큰을 반환합니다.
  - 유효한 리프레시 토큰은 레디스에 저장합니다. 리프레시 토큰의 TTL은 리프레시 토큰의 만료시간과 동일하게 적용할 계획입니다. 
- 기존의 카카오 로그인과 게스트 로그인에서도 리프레시 토큰을 반환하도록 수정했습니다.

## Screenshot 📸

## Uncompleted Tasks 😅

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 토큰 갱신 기능 추가 - 리프레시 토큰을 통해 만료된 액세스 토큰을 갱신할 수 있습니다.
* 향상된 로그인 응답 - 모든 로그인(카카오, 게스트) 시 리프레시 토큰이 함께 제공됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->