### PR TITLE
[Refactor] 보호글 랜덤 조회 API가 foundDate를 기준으로 하도록 변경 

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -18,6 +19,6 @@ public interface ProtectingReportRepository extends JpaRepository<ProtectingRepo
 
     List<ProtectingReport> findByNoticeNumberIn(Set<String> noticeNumbers);
 
-    List<ProtectingReport> findByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+    List<ProtectingReport> findByDate(LocalDate date);
 }
 

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImpl.java
@@ -14,8 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -36,9 +34,8 @@ public class ProtectingReportRetrieveWithS3ServiceImpl implements ProtectingRepo
     @Transactional(readOnly = true)
     public List<ProtectingReportDetailResponseDTO> getRandomProtectingReportsWithS3(int count) {
 
-        LocalDateTime end = LocalDate.now().atTime(LocalTime.MAX);
-        LocalDateTime start = LocalDate.now().minusDays(1).atStartOfDay();
-        List<ProtectingReport> allReports = protectingReportRepository.findByCreatedAtBetween(start, end);
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        List<ProtectingReport> allReports = protectingReportRepository.findByDate(yesterday);
 
         if(allReports.isEmpty()) {
             //204 no content
@@ -47,7 +44,8 @@ public class ProtectingReportRetrieveWithS3ServiceImpl implements ProtectingRepo
 
         Collections.shuffle(allReports);
 
-        List<ProtectingReport> selectedReports = allReports.stream().limit(count).toList();
+        int limit = Math.max(1, count);
+        List<ProtectingReport> selectedReports = allReports.stream().limit(limit).toList();
 
         List<ProtectingReportDetailResponseDTO> result = new ArrayList<>();
 

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
@@ -560,7 +561,7 @@ class ReportControllerTest {
         // given
         User user = testInitializer.createTestUser();
         ProtectingReport report = testInitializer.createTestProtectingReportWithImage(user);
-
+        ReflectionTestUtils.setField(report, "date", LocalDate.now().minusDays(1));
         protectingReportRepository.saveAndFlush(report);
 
         String originalImageUrl = "https://img.com/1.png";

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/ProtectingReportRetrieveWithS3ServiceImplTest.java
@@ -20,7 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -55,7 +55,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
     @DisplayName("어제, 오늘 게시된 보호글이 하나도 없으면 빈 리스트를 반환")
     void getRandomProtectingReportsWithS3_whenNoReports_thenThrow() {
         // given
-        when(protectingReportRepository.findByCreatedAtBetween(any(LocalDateTime.class), any(LocalDateTime.class))).thenReturn(Collections.emptyList());
+        when(protectingReportRepository.findByDate(any(LocalDate.class))).thenReturn(Collections.emptyList());
 
         // when
         List<ProtectingReportDetailResponseDTO> result =
@@ -65,7 +65,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         assertThat(result).isEmpty();
 
         verify(protectingReportRepository, times(1))
-                .findByCreatedAtBetween(any(LocalDateTime.class), any(LocalDateTime.class));
+                .findByDate(any(LocalDate.class));
 
         verifyNoInteractions(imageUploader, protectingReportDetailStrategy);
     }
@@ -81,7 +81,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(report1.getReportImages()).thenReturn(Collections.<ReportImage>emptyList());
         when(report2.getReportImages()).thenReturn(Collections.<ReportImage>emptyList());
 
-        when(protectingReportRepository.findByCreatedAtBetween(any(), any())).thenReturn(new ArrayList<>(List.of(report1, report2)));
+        when(protectingReportRepository.findByDate(any())).thenReturn(new ArrayList<>(List.of(report1, report2)));
 
         ProtectingReportDetailResponseDTO dto1 = mock(ProtectingReportDetailResponseDTO.class);
         ProtectingReportDetailResponseDTO dto2 = mock(ProtectingReportDetailResponseDTO.class);
@@ -100,7 +100,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
                 .hasSize(2)
                 .containsExactlyInAnyOrder(dto1, dto2);
 
-        verify(protectingReportRepository, times(1)).findByCreatedAtBetween(any(), any());
+        verify(protectingReportRepository, times(1)).findByDate(any());
         verify(protectingReportDetailStrategy, times(2))
                 .toDetailDto(any(ProtectingReport.class), anyList(), eq(false));
 
@@ -120,7 +120,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(r2.getReportImages()).thenReturn(Collections.emptyList());
         when(r3.getReportImages()).thenReturn(Collections.emptyList());
 
-        when(protectingReportRepository.findByCreatedAtBetween(any(), any()))
+        when(protectingReportRepository.findByDate(any()))
                 .thenReturn(new ArrayList<>(List.of(r1, r2, r3)));
 
         when(protectingReportDetailStrategy.toDetailDto(any(), anyList(), eq(false)))
@@ -133,7 +133,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         // then
         assertThat(result).hasSize(2);
 
-        verify(protectingReportRepository).findByCreatedAtBetween(any(), any());
+        verify(protectingReportRepository).findByDate(any());
         verify(protectingReportDetailStrategy, times(2))
                 .toDetailDto(any(ProtectingReport.class), anyList(), eq(false));
     }
@@ -150,7 +150,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(img1.getImageUrl()).thenReturn("http://localhost:65535/nonexistent");
 
         when(report.getReportImages()).thenReturn(List.of(img1));
-        when(protectingReportRepository.findByCreatedAtBetween(any(), any()))
+        when(protectingReportRepository.findByDate(any()))
                 .thenReturn(new ArrayList<>(List.of(report)));
 
         ProtectingReportDetailResponseDTO dto = mock(ProtectingReportDetailResponseDTO.class);
@@ -179,7 +179,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(img2.getImageUrl()).thenReturn("http://example.com/2.jpg");
         when(report.getReportImages()).thenReturn(List.of(img1, img2));
 
-        when(protectingReportRepository.findByCreatedAtBetween(any(), any()))
+        when(protectingReportRepository.findByDate(any()))
                 .thenReturn(new ArrayList<>(List.of(report)));
 
         // RestTemplate 가 바이트 배열 내려줌
@@ -237,7 +237,7 @@ class ProtectingReportRetrieveWithS3ServiceImplTest {
         when(img2.getImageUrl()).thenReturn("http://example.com/2.jpg");
         when(report.getReportImages()).thenReturn(List.of(img1, img2));
 
-        when(protectingReportRepository.findByCreatedAtBetween(any(), any()))
+        when(protectingReportRepository.findByDate(any()))
                 .thenReturn(new ArrayList<>(List.of(report)));
 
         //1번 이미지는 S3 업로드 시 FileUploadingFailedException 발생


### PR DESCRIPTION
## Related issue 🛠
- closed #151 

## Work Description 📝
- 기존 로직에서 날짜 정렬 기준을 foundDate로 변경했습니다.
- 하루 전 공고 중 count 만큼의 공고를 랜덤으로 정렬하여 응답합니다.

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅

## To Reviewers 📢
