### PR TITLE
[Feat] 스케줄링을 위한, S3 URL을 반환하는 신고글 랜덤 조회 기능 구현

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -9,6 +9,7 @@ import com.kuit.findyou.domain.report.dto.response.ProtectingReportDetailRespons
 import com.kuit.findyou.domain.report.dto.response.WitnessReportDetailResponseDTO;
 import com.kuit.findyou.domain.report.model.ReportTag;
 import com.kuit.findyou.domain.report.service.facade.ReportServiceFacade;
+import com.kuit.findyou.domain.report.service.retrieve.MissingReportRetrieveWithS3Service;
 import com.kuit.findyou.domain.report.service.retrieve.ProtectingReportRetrieveWithS3Service;
 import com.kuit.findyou.global.common.annotation.CustomExceptionDescription;
 import com.kuit.findyou.global.common.response.BaseResponse;
@@ -40,6 +41,7 @@ public class ReportController {
 
     private final ReportServiceFacade reportServiceFacade;
     private final ProtectingReportRetrieveWithS3Service protectingReportRetrieveWithS3Service;
+    private final MissingReportRetrieveWithS3Service missingReportRetrieveWithS3Service;
 
     @Operation(summary = "보호글 상세 조회 API", description = "보호글의 정보를 상세 조회하기 위한 API")
     @GetMapping("/protecting-reports/{reportId}")
@@ -126,6 +128,24 @@ public class ReportController {
     ) {
         List<ProtectingReportDetailResponseDTO> details =
                 protectingReportRetrieveWithS3Service.getRandomProtectingReportsWithS3(count);
+
+        if (details.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(BaseResponse.ok(details));
+    }
+
+    @Operation(
+            summary = "실종글 S3 이미지 포함 랜덤 조회 API", description = "랜덤으로 실종글을 선택하여 원본 이미지를 S3에 업로드 후, S3 URL 포함 실종글을 리스트로 반환합니다."
+    )
+    @GetMapping("/missing-reports/random-s3")
+    @CustomExceptionDescription(DEFAULT)
+    public ResponseEntity<?> getRandomMissingReportsWithS3(
+            @RequestParam(name = "count", defaultValue = "1")
+            @Min(1) @Max(10) int count
+    ) {
+        List<MissingReportDetailResponseDTO> details =
+                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(count);
 
         if (details.isEmpty()) {
             return ResponseEntity.noContent().build();

--- a/src/main/java/com/kuit/findyou/domain/report/repository/MissingReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/MissingReportRepository.java
@@ -1,11 +1,12 @@
 package com.kuit.findyou.domain.report.repository;
 
 import com.kuit.findyou.domain.report.model.MissingReport;
-import com.kuit.findyou.domain.report.model.ProtectingReport;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 
@@ -14,4 +15,6 @@ public interface MissingReportRepository extends JpaRepository<MissingReport, Lo
 
     @EntityGraph(attributePaths = {"reportImages"})
     Optional<MissingReport> findWithImagesById(Long id);
+
+    List<MissingReport> findByDate(LocalDate date);
 }

--- a/src/main/java/com/kuit/findyou/domain/report/service/detail/strategy/MissingReportDetailStrategy.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/detail/strategy/MissingReportDetailStrategy.java
@@ -8,7 +8,7 @@ import com.kuit.findyou.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.math.BigDecimal;
+import java.util.List;
 
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.MISSING_REPORT_NOT_FOUND;
 
@@ -32,6 +32,25 @@ public class MissingReportDetailStrategy implements ReportDetailStrategy<Missing
                 ReportFormatUtil.safeValue(report.getSignificant()),
                 ReportFormatUtil.safeValue(report.getLandmark()),       // missingLocation
                 ReportFormatUtil.safeValue(report.getAddress()),        // missingAddress
+                ReportFormatUtil.formatCoordinate(report.getLatitude()),
+                ReportFormatUtil.formatCoordinate(report.getLongitude()),
+                ReportFormatUtil.safeValue(report.getReporterName()),
+                ReportFormatUtil.safeValue(report.getReporterTel()),
+                interest
+        );
+    }
+    public MissingReportDetailResponseDTO toDetailDto(MissingReport report, List<String> imageUrls, boolean interest) {
+        return new MissingReportDetailResponseDTO(
+                imageUrls,
+                ReportFormatUtil.safeValue(report.getBreed()),
+                report.getTag().getValue(),
+                ReportFormatUtil.safeValue(report.getAge()),
+                ReportFormatUtil.safeSex(report.getSex()),
+                ReportFormatUtil.safeDate(report.getDate()),
+                ReportFormatUtil.safeValue(report.getRfid()),
+                ReportFormatUtil.safeValue(report.getSignificant()),
+                ReportFormatUtil.safeValue(report.getLandmark()),
+                ReportFormatUtil.safeValue(report.getAddress()),
                 ReportFormatUtil.formatCoordinate(report.getLatitude()),
                 ReportFormatUtil.formatCoordinate(report.getLongitude()),
                 ReportFormatUtil.safeValue(report.getReporterName()),

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/MissingReportRetrieveWithS3Service.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/MissingReportRetrieveWithS3Service.java
@@ -1,0 +1,9 @@
+package com.kuit.findyou.domain.report.service.retrieve;
+
+import com.kuit.findyou.domain.report.dto.response.MissingReportDetailResponseDTO;
+
+import java.util.List;
+
+public interface MissingReportRetrieveWithS3Service {
+    List<MissingReportDetailResponseDTO> getRandomMissingReportsWithS3(int count);
+}

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/MissingReportRetrieveWithS3ServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/MissingReportRetrieveWithS3ServiceImpl.java
@@ -5,30 +5,22 @@ import com.kuit.findyou.domain.report.dto.response.MissingReportDetailResponseDT
 import com.kuit.findyou.domain.report.model.MissingReport;
 import com.kuit.findyou.domain.report.repository.MissingReportRepository;
 import com.kuit.findyou.domain.report.service.detail.strategy.MissingReportDetailStrategy;
-import com.kuit.findyou.global.infrastructure.FileUploadingFailedException;
-import com.kuit.findyou.global.infrastructure.ImageUploader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
 @Slf4j
 public class MissingReportRetrieveWithS3ServiceImpl implements MissingReportRetrieveWithS3Service{
     private final MissingReportRepository missingReportRepository;
-    private final ImageUploader imageUploader;
     private final MissingReportDetailStrategy missingReportDetailStrategy;
-
-    //외부 URL에서 이미지를 받아오기 위한 HTTP 클라이언트
-    private final RestTemplate restTemplate;
 
     @Override
     @Transactional(readOnly = true)
@@ -51,38 +43,14 @@ public class MissingReportRetrieveWithS3ServiceImpl implements MissingReportRetr
 
         for (MissingReport report : selectedReports) {
 
-            // 실종글에 연결된 원본 이미지 가져오기
-            List<ReportImage> reportImages = report.getReportImages();
-            List<String> originalUrls = reportImages.stream()
+            List<String> imageUrls = report.getReportImages().stream()
                     .map(ReportImage::getImageUrl)
+                    .filter(url -> url != null && !url.isBlank())
+                    .distinct()
                     .toList();
 
-            // S3에 업로드하기
-            List<String> s3Urls = new ArrayList<>();
-            for (String url : originalUrls) {
-                try {
-                    byte[] imageBytes = restTemplate.getForObject(url, byte[].class);
-                    if (imageBytes == null || imageBytes.length == 0) {
-                        log.warn("[MissingReportS3] 빈 이미지 응답: url={}", url);
-                        continue;
-                    }
-
-                    String key = "missing/" + report.getId() + "/" + UUID.randomUUID() + ".jpg";
-                    String s3Url = imageUploader.upload(imageBytes, key, "image/jpeg");
-                    s3Urls.add(s3Url);
-
-                } catch (FileUploadingFailedException e) {
-                    // S3 자체 장애, 권한 등의 문제 발생 시
-                    log.error("[MissingReportS3] S3 업로드 실패 - reportId={}, url={}, message={}",
-                            report.getId(), url, e.getMessage(), e);
-                } catch (Exception e) {
-                    log.error("[MissingReportS3] 이미지 처리 중 예기치 못한 오류 발생 - reportId={}, url={}",
-                            report.getId(), url, e);
-                }
-            }
-
             MissingReportDetailResponseDTO dto =
-                    missingReportDetailStrategy.toDetailDto(report, s3Urls,false);
+                    missingReportDetailStrategy.toDetailDto(report, imageUrls,false);
             result.add(dto);
         }
 

--- a/src/main/java/com/kuit/findyou/domain/report/service/retrieve/MissingReportRetrieveWithS3ServiceImpl.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/retrieve/MissingReportRetrieveWithS3ServiceImpl.java
@@ -1,0 +1,91 @@
+package com.kuit.findyou.domain.report.service.retrieve;
+
+import com.kuit.findyou.domain.image.model.ReportImage;
+import com.kuit.findyou.domain.report.dto.response.MissingReportDetailResponseDTO;
+import com.kuit.findyou.domain.report.model.MissingReport;
+import com.kuit.findyou.domain.report.repository.MissingReportRepository;
+import com.kuit.findyou.domain.report.service.detail.strategy.MissingReportDetailStrategy;
+import com.kuit.findyou.global.infrastructure.FileUploadingFailedException;
+import com.kuit.findyou.global.infrastructure.ImageUploader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class MissingReportRetrieveWithS3ServiceImpl implements MissingReportRetrieveWithS3Service{
+    private final MissingReportRepository missingReportRepository;
+    private final ImageUploader imageUploader;
+    private final MissingReportDetailStrategy missingReportDetailStrategy;
+
+    //외부 URL에서 이미지를 받아오기 위한 HTTP 클라이언트
+    private final RestTemplate restTemplate;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MissingReportDetailResponseDTO> getRandomMissingReportsWithS3(int count) {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+
+        List<MissingReport> allReports = missingReportRepository.findByDate(yesterday);
+
+        if (allReports.isEmpty()) {
+            // 204 no content
+            return Collections.emptyList();
+        }
+
+        Collections.shuffle(allReports);
+
+        int limit = Math.max(1, count);
+        List<MissingReport> selectedReports = allReports.stream().limit(limit).toList();
+
+        List<MissingReportDetailResponseDTO> result = new ArrayList<>();
+
+        for (MissingReport report : selectedReports) {
+
+            // 실종글에 연결된 원본 이미지 가져오기
+            List<ReportImage> reportImages = report.getReportImages();
+            List<String> originalUrls = reportImages.stream()
+                    .map(ReportImage::getImageUrl)
+                    .toList();
+
+            // S3에 업로드하기
+            List<String> s3Urls = new ArrayList<>();
+            for (String url : originalUrls) {
+                try {
+                    byte[] imageBytes = restTemplate.getForObject(url, byte[].class);
+                    if (imageBytes == null || imageBytes.length == 0) {
+                        log.warn("[MissingReportS3] 빈 이미지 응답: url={}", url);
+                        continue;
+                    }
+
+                    String key = "missing/" + report.getId() + "/" + UUID.randomUUID() + ".jpg";
+                    String s3Url = imageUploader.upload(imageBytes, key, "image/jpeg");
+                    s3Urls.add(s3Url);
+
+                } catch (FileUploadingFailedException e) {
+                    // S3 자체 장애, 권한 등의 문제 발생 시
+                    log.error("[MissingReportS3] S3 업로드 실패 - reportId={}, url={}, message={}",
+                            report.getId(), url, e.getMessage(), e);
+                } catch (Exception e) {
+                    log.error("[MissingReportS3] 이미지 처리 중 예기치 못한 오류 발생 - reportId={}, url={}",
+                            report.getId(), url, e);
+                }
+            }
+
+            MissingReportDetailResponseDTO dto =
+                    missingReportDetailStrategy.toDetailDto(report, s3Urls,false);
+            result.add(dto);
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
+++ b/src/main/java/com/kuit/findyou/global/config/SecurityConfig.java
@@ -63,6 +63,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v2/users").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v2/users/check/duplicate-nickname").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v2/reports/protecting-reports/random-s3").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v2/reports/missing-reports/random-s3").permitAll()
                         .anyRequest().authenticated());
 
         // 토큰 검증 필터 추가

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -1,10 +1,11 @@
 package com.kuit.findyou.domain.report.controller;
 
-import com.kuit.findyou.domain.image.repository.ReportImageRepository;
 import com.kuit.findyou.domain.report.dto.request.CreateMissingReportRequest;
 import com.kuit.findyou.domain.report.dto.request.CreateWitnessReportRequest;
 import com.kuit.findyou.domain.report.dto.request.ReportViewType;
+import com.kuit.findyou.domain.report.model.MissingReport;
 import com.kuit.findyou.domain.report.model.ProtectingReport;
+import com.kuit.findyou.domain.report.repository.MissingReportRepository;
 import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.global.common.util.DatabaseCleaner;
@@ -24,6 +25,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
@@ -52,7 +54,7 @@ class ReportControllerTest {
     private ProtectingReportRepository protectingReportRepository;
 
     @Autowired
-    private ReportImageRepository reportImageRepository;
+    private MissingReportRepository missingReportRepository;
 
 
     @LocalServerPort
@@ -584,7 +586,7 @@ class ReportControllerTest {
                 .body("success", equalTo(true))
                 .body("code", equalTo(200))
                 .body("data.size()", equalTo(1))
-                .body("data[0].imageUrls[0]", equalTo("https://cdn.findyou.store/random1.jpg"))
+                .body(  "data[0].imageUrls[0]", equalTo("https://cdn.findyou.store/random1.jpg"))
                 .body("data[0].breed", equalTo("믹스견"))
                 .body("data[0].tag", equalTo("보호중"))
                 .body("data[0].careName", equalTo("광진보호소"));
@@ -607,4 +609,60 @@ class ReportControllerTest {
                 .log().all()
                 .statusCode(204);
     }
+    @Test
+    @DisplayName("실종글 랜덤 조회 -> S3 URL 포함 응답")
+    void getRandomMissingReportsWithS3_success() {
+        // given
+        User user = testInitializer.createTestUser();
+        MissingReport report =
+                testInitializer.createTestMissingReportWithImage(user);
+
+        ReflectionTestUtils.setField(report, "date", LocalDate.now().minusDays(1));
+
+        missingReportRepository.saveAndFlush(report);
+
+        String originalImageUrl = "https://img.com/missing.png";
+
+        when(restTemplate.getForObject(eq(originalImageUrl), eq(byte[].class)))
+                .thenReturn(new byte[]{1, 2, 3});
+
+        when(imageUploader.upload(any(byte[].class), anyString(), eq("image/jpeg")))
+                .thenReturn("https://cdn.findyou.store/random-missing1.jpg");
+
+        // when & then
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .param("count", 1)
+                .when()
+                .get("/api/v2/reports/missing-reports/random-s3")
+                .then()
+                .log().all()
+                .statusCode(200)
+                .body("success", equalTo(true))
+                .body("code", equalTo(200))
+                .body("data.size()", equalTo(1))
+                .body("data[0].imageUrls[0]", equalTo("https://cdn.findyou.store/random-missing1.jpg"))
+                .body("data[0].breed", equalTo("포메라니안"))
+                .body("data[0].tag", equalTo("실종신고"));
+    }
+
+    @Test
+    @DisplayName("실종글이 없을 경우 -> 204 No Content 응답 (Body 없음)")
+    void getRandomMissingReportsWithS3_noContent() {
+        // given
+        // DB에 아무것도 저장하지 않음 (빈 상태)
+
+        // when & then
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .param("count", 1)
+                .when()
+                .get("/api/v2/reports/missing-reports/random-s3")
+                .then()
+                .log().all()
+                .statusCode(204);
+    }
+
 }

--- a/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/controller/ReportControllerTest.java
@@ -621,14 +621,6 @@ class ReportControllerTest {
 
         missingReportRepository.saveAndFlush(report);
 
-        String originalImageUrl = "https://img.com/missing.png";
-
-        when(restTemplate.getForObject(eq(originalImageUrl), eq(byte[].class)))
-                .thenReturn(new byte[]{1, 2, 3});
-
-        when(imageUploader.upload(any(byte[].class), anyString(), eq("image/jpeg")))
-                .thenReturn("https://cdn.findyou.store/random-missing1.jpg");
-
         // when & then
         given()
                 .contentType(ContentType.JSON)
@@ -642,7 +634,7 @@ class ReportControllerTest {
                 .body("success", equalTo(true))
                 .body("code", equalTo(200))
                 .body("data.size()", equalTo(1))
-                .body("data[0].imageUrls[0]", equalTo("https://cdn.findyou.store/random-missing1.jpg"))
+                .body("data[0].imageUrls[0]", equalTo("https://img.com/missing.png"))
                 .body("data[0].breed", equalTo("포메라니안"))
                 .body("data[0].tag", equalTo("실종신고"));
     }

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/MissingReportRetrieveWithS3ServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/MissingReportRetrieveWithS3ServiceImplTest.java
@@ -1,0 +1,276 @@
+package com.kuit.findyou.domain.report.service.retrieve;
+
+import com.kuit.findyou.domain.image.model.ReportImage;
+import com.kuit.findyou.domain.report.dto.response.MissingReportDetailResponseDTO;
+import com.kuit.findyou.domain.report.model.MissingReport;
+import com.kuit.findyou.domain.report.repository.MissingReportRepository;
+import com.kuit.findyou.domain.report.service.detail.strategy.MissingReportDetailStrategy;
+import com.kuit.findyou.global.infrastructure.FileUploadingFailedException;
+import com.kuit.findyou.global.infrastructure.ImageUploader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Transactional
+@ActiveProfiles("test")
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MissingReportRetrieveWithS3ServiceImplTest {
+
+    @Mock
+    private MissingReportRepository missingReportRepository;
+
+    @Mock
+    private ImageUploader imageUploader;
+
+    @Mock
+    private MissingReportDetailStrategy missingReportDetailStrategy;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private MissingReportRetrieveWithS3ServiceImpl missingReportRetrieveWithS3Service;
+
+    @Test
+    @DisplayName("어제 날짜 실종글이 없으면 빈 리스트 반환")
+    void getRandomMissingReportsWithS3_whenNoReports_thenReturnEmpty() {
+        // given
+        when(missingReportRepository.findByDate(any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        List<MissingReportDetailResponseDTO> result =
+                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(3);
+
+        // then
+        assertThat(result).isEmpty();
+
+        verify(missingReportRepository, times(1)).findByDate(any(LocalDate.class));
+        verifyNoInteractions(imageUploader, missingReportDetailStrategy);
+    }
+
+    @Test
+    @DisplayName("요청 개수보다 실종글이 적으면 전체 개수만큼만 반환")
+    void getRandomMissingReportsWithS3_whenCountGreaterThanSize_thenReturnAllReports() {
+        // given
+        MissingReport report1 = mock(MissingReport.class);
+        MissingReport report2 = mock(MissingReport.class);
+
+        when(report1.getReportImages()).thenReturn(Collections.<ReportImage>emptyList());
+        when(report2.getReportImages()).thenReturn(Collections.<ReportImage>emptyList());
+
+        when(missingReportRepository.findByDate(any(LocalDate.class)))
+                .thenReturn(new ArrayList<>(List.of(report1, report2)));
+
+        MissingReportDetailResponseDTO dto1 = mock(MissingReportDetailResponseDTO.class);
+        MissingReportDetailResponseDTO dto2 = mock(MissingReportDetailResponseDTO.class);
+
+        when(missingReportDetailStrategy.toDetailDto(eq(report1), anyList(), eq(false))).thenReturn(dto1);
+        when(missingReportDetailStrategy.toDetailDto(eq(report2), anyList(), eq(false))).thenReturn(dto2);
+
+        // when
+        List<MissingReportDetailResponseDTO> result =
+                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(10);
+
+        // then
+        assertThat(result).hasSize(2).containsExactlyInAnyOrder(dto1, dto2);
+
+        verify(missingReportRepository, times(1)).findByDate(any(LocalDate.class));
+        verify(missingReportDetailStrategy, times(2))
+                .toDetailDto(any(MissingReport.class), anyList(), eq(false));
+
+        verifyNoInteractions(imageUploader);
+    }
+
+    @Test
+    @DisplayName("요청 개수가 전체 개수보다 적으면 요청 개수만큼만 반환")
+    void getRandomMissingReportsWithS3_whenCountLessThanSize_thenReturnCountReports() {
+        // given
+        MissingReport r1 = mock(MissingReport.class);
+        MissingReport r2 = mock(MissingReport.class);
+        MissingReport r3 = mock(MissingReport.class);
+
+        when(r1.getReportImages()).thenReturn(Collections.emptyList());
+        when(r2.getReportImages()).thenReturn(Collections.emptyList());
+        when(r3.getReportImages()).thenReturn(Collections.emptyList());
+
+        when(missingReportRepository.findByDate(any(LocalDate.class)))
+                .thenReturn(new ArrayList<>(List.of(r1, r2, r3)));
+
+        when(missingReportDetailStrategy.toDetailDto(any(), anyList(), eq(false)))
+                .thenReturn(mock(MissingReportDetailResponseDTO.class));
+
+        // when
+        List<MissingReportDetailResponseDTO> result =
+                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(2);
+
+        // then
+        assertThat(result).hasSize(2);
+
+        verify(missingReportRepository, times(1)).findByDate(any(LocalDate.class));
+        verify(missingReportDetailStrategy, times(2))
+                .toDetailDto(any(MissingReport.class), anyList(), eq(false));
+    }
+
+    @Test
+    @DisplayName("이미지 다운로드에서 예외가 나도 전체 API는 실패하지 않고 DTO는 반환")
+    void getRandomMissingReportsWithS3_whenUnexpectedException_thenContinue() {
+        // given
+        MissingReport report = mock(MissingReport.class);
+        when(report.getId()).thenReturn(1L);
+
+        ReportImage img1 = mock(ReportImage.class);
+        when(img1.getImageUrl()).thenReturn("http://localhost:65535/nonexistent");
+        when(report.getReportImages()).thenReturn(List.of(img1));
+
+        when(missingReportRepository.findByDate(any(LocalDate.class)))
+                .thenReturn(new ArrayList<>(List.of(report)));
+
+        MissingReportDetailResponseDTO dto = mock(MissingReportDetailResponseDTO.class);
+        when(missingReportDetailStrategy.toDetailDto(eq(report), anyList(), eq(false))).thenReturn(dto);
+
+        // RestTemplate이 예외 던지게(다운로드 실패)
+        when(restTemplate.getForObject(anyString(), eq(byte[].class)))
+                .thenThrow(new RuntimeException("다운로드 오류"));
+
+        // when
+        List<MissingReportDetailResponseDTO> result =
+                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(1);
+
+        // then
+        assertThat(result).hasSize(1).containsExactly(dto);
+    }
+
+    @Test
+    @DisplayName("이미지를 정상적으로 받으면 S3 업로드되고 업로드된 URL 리스트가 DTO 생성에 전달된다")
+    void getRandomMissingReportsWithS3_successUploadFlow() {
+        // given
+        MissingReport report = mock(MissingReport.class);
+        when(report.getId()).thenReturn(100L);
+
+        ReportImage img1 = mock(ReportImage.class);
+        ReportImage img2 = mock(ReportImage.class);
+
+        when(img1.getImageUrl()).thenReturn("http://example.com/1.jpg");
+        when(img2.getImageUrl()).thenReturn("http://example.com/2.jpg");
+        when(report.getReportImages()).thenReturn(List.of(img1, img2));
+
+        when(missingReportRepository.findByDate(any(LocalDate.class)))
+                .thenReturn(new ArrayList<>(List.of(report)));
+
+        when(restTemplate.getForObject(eq("http://example.com/1.jpg"), eq(byte[].class)))
+                .thenReturn(new byte[]{1, 2, 3});
+        when(restTemplate.getForObject(eq("http://example.com/2.jpg"), eq(byte[].class)))
+                .thenReturn(new byte[]{4, 5, 6});
+
+        when(imageUploader.upload(any(byte[].class), anyString(), eq("image/jpeg")))
+                .thenReturn("https://s3.findyou.store/1.jpg", "https://s3.findyou.store/2.jpg");
+
+        MissingReportDetailResponseDTO dto = mock(MissingReportDetailResponseDTO.class);
+
+        ArgumentCaptor<List<String>> s3UrlsCaptor = ArgumentCaptor.forClass(List.class);
+        when(missingReportDetailStrategy.toDetailDto(eq(report), s3UrlsCaptor.capture(), eq(false)))
+                .thenReturn(dto);
+
+        // when
+        List<MissingReportDetailResponseDTO> result =
+                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(1);
+
+        // then
+        assertThat(result).hasSize(1).containsExactly(dto);
+
+        List<String> capturedUrls = s3UrlsCaptor.getValue();
+        assertThat(capturedUrls).containsExactly(
+                "https://s3.findyou.store/1.jpg",
+                "https://s3.findyou.store/2.jpg"
+        );
+
+        verify(restTemplate, times(1)).getForObject("http://example.com/1.jpg", byte[].class);
+        verify(restTemplate, times(1)).getForObject("http://example.com/2.jpg", byte[].class);
+        verify(imageUploader, times(2)).upload(any(byte[].class), anyString(), eq("image/jpeg"));
+    }
+
+    @Test
+    @DisplayName("S3 업로드/다운로드에서 예외가 발생해도 DTO는 정상 반환되고, 성공한 URL만 전달된다")
+    void getRandomMissingReportsWithS3_whenUploadFails_thenContinuePerImage() {
+        // given
+        MissingReport report = mock(MissingReport.class);
+        when(report.getId()).thenReturn(200L);
+
+        ReportImage img1 = mock(ReportImage.class);
+        ReportImage img2 = mock(ReportImage.class);
+
+        when(img1.getImageUrl()).thenReturn("http://example.com/1.jpg");
+        when(img2.getImageUrl()).thenReturn("http://example.com/2.jpg");
+        when(report.getReportImages()).thenReturn(List.of(img1, img2));
+
+        when(missingReportRepository.findByDate(any(LocalDate.class)))
+                .thenReturn(new ArrayList<>(List.of(report)));
+
+        // 1번: 다운로드 성공 -> 업로드 실패
+        when(restTemplate.getForObject("http://example.com/1.jpg", byte[].class))
+                .thenReturn(new byte[]{1, 2, 3});
+        when(imageUploader.upload(any(byte[].class), anyString(), eq("image/jpeg")))
+                .thenThrow(new FileUploadingFailedException("업로드 실패"));
+
+        // 2번: 다운로드 자체 실패
+        when(restTemplate.getForObject("http://example.com/2.jpg", byte[].class))
+                .thenThrow(new RuntimeException("다운로드 오류"));
+
+        MissingReportDetailResponseDTO dto = mock(MissingReportDetailResponseDTO.class);
+
+        ArgumentCaptor<List<String>> s3UrlsCaptor = ArgumentCaptor.forClass(List.class);
+        when(missingReportDetailStrategy.toDetailDto(eq(report), s3UrlsCaptor.capture(), eq(false)))
+                .thenReturn(dto);
+
+        // when
+        List<MissingReportDetailResponseDTO> result =
+                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(1);
+
+        // then
+        assertThat(result).hasSize(1).containsExactly(dto);
+
+        // 둘 다 실패했으니 URL은 빈 리스트
+        assertThat(s3UrlsCaptor.getValue()).isEmpty();
+
+        verify(restTemplate, times(1)).getForObject("http://example.com/1.jpg", byte[].class);
+        verify(restTemplate, times(1)).getForObject("http://example.com/2.jpg", byte[].class);
+        verify(imageUploader, times(1)).upload(any(byte[].class), anyString(), eq("image/jpeg"));
+    }
+
+    @Test
+    @DisplayName("Repository 조회 날짜가 '어제'로 들어간다")
+    void getRandomMissingReportsWithS3_verifyRepositoryDateIsYesterday() {
+        // given
+        when(missingReportRepository.findByDate(any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+
+        ArgumentCaptor<LocalDate> dateCaptor = ArgumentCaptor.forClass(LocalDate.class);
+
+        // when
+        missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(1);
+
+        // then
+        verify(missingReportRepository).findByDate(dateCaptor.capture());
+        assertThat(dateCaptor.getValue()).isEqualTo(LocalDate.now().minusDays(1));
+    }
+}

--- a/src/test/java/com/kuit/findyou/domain/report/service/retrieve/MissingReportRetrieveWithS3ServiceImplTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/retrieve/MissingReportRetrieveWithS3ServiceImplTest.java
@@ -5,8 +5,6 @@ import com.kuit.findyou.domain.report.dto.response.MissingReportDetailResponseDT
 import com.kuit.findyou.domain.report.model.MissingReport;
 import com.kuit.findyou.domain.report.repository.MissingReportRepository;
 import com.kuit.findyou.domain.report.service.detail.strategy.MissingReportDetailStrategy;
-import com.kuit.findyou.global.infrastructure.FileUploadingFailedException;
-import com.kuit.findyou.global.infrastructure.ImageUploader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +16,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -38,14 +35,10 @@ class MissingReportRetrieveWithS3ServiceImplTest {
     @Mock
     private MissingReportRepository missingReportRepository;
 
-    @Mock
-    private ImageUploader imageUploader;
 
     @Mock
     private MissingReportDetailStrategy missingReportDetailStrategy;
 
-    @Mock
-    private RestTemplate restTemplate;
 
     @InjectMocks
     private MissingReportRetrieveWithS3ServiceImpl missingReportRetrieveWithS3Service;
@@ -65,7 +58,6 @@ class MissingReportRetrieveWithS3ServiceImplTest {
         assertThat(result).isEmpty();
 
         verify(missingReportRepository, times(1)).findByDate(any(LocalDate.class));
-        verifyNoInteractions(imageUploader, missingReportDetailStrategy);
     }
 
     @Test
@@ -98,7 +90,6 @@ class MissingReportRetrieveWithS3ServiceImplTest {
         verify(missingReportDetailStrategy, times(2))
                 .toDetailDto(any(MissingReport.class), anyList(), eq(false));
 
-        verifyNoInteractions(imageUploader);
     }
 
     @Test
@@ -132,132 +123,6 @@ class MissingReportRetrieveWithS3ServiceImplTest {
     }
 
     @Test
-    @DisplayName("이미지 다운로드에서 예외가 나도 전체 API는 실패하지 않고 DTO는 반환")
-    void getRandomMissingReportsWithS3_whenUnexpectedException_thenContinue() {
-        // given
-        MissingReport report = mock(MissingReport.class);
-        when(report.getId()).thenReturn(1L);
-
-        ReportImage img1 = mock(ReportImage.class);
-        when(img1.getImageUrl()).thenReturn("http://localhost:65535/nonexistent");
-        when(report.getReportImages()).thenReturn(List.of(img1));
-
-        when(missingReportRepository.findByDate(any(LocalDate.class)))
-                .thenReturn(new ArrayList<>(List.of(report)));
-
-        MissingReportDetailResponseDTO dto = mock(MissingReportDetailResponseDTO.class);
-        when(missingReportDetailStrategy.toDetailDto(eq(report), anyList(), eq(false))).thenReturn(dto);
-
-        // RestTemplate이 예외 던지게(다운로드 실패)
-        when(restTemplate.getForObject(anyString(), eq(byte[].class)))
-                .thenThrow(new RuntimeException("다운로드 오류"));
-
-        // when
-        List<MissingReportDetailResponseDTO> result =
-                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(1);
-
-        // then
-        assertThat(result).hasSize(1).containsExactly(dto);
-    }
-
-    @Test
-    @DisplayName("이미지를 정상적으로 받으면 S3 업로드되고 업로드된 URL 리스트가 DTO 생성에 전달된다")
-    void getRandomMissingReportsWithS3_successUploadFlow() {
-        // given
-        MissingReport report = mock(MissingReport.class);
-        when(report.getId()).thenReturn(100L);
-
-        ReportImage img1 = mock(ReportImage.class);
-        ReportImage img2 = mock(ReportImage.class);
-
-        when(img1.getImageUrl()).thenReturn("http://example.com/1.jpg");
-        when(img2.getImageUrl()).thenReturn("http://example.com/2.jpg");
-        when(report.getReportImages()).thenReturn(List.of(img1, img2));
-
-        when(missingReportRepository.findByDate(any(LocalDate.class)))
-                .thenReturn(new ArrayList<>(List.of(report)));
-
-        when(restTemplate.getForObject(eq("http://example.com/1.jpg"), eq(byte[].class)))
-                .thenReturn(new byte[]{1, 2, 3});
-        when(restTemplate.getForObject(eq("http://example.com/2.jpg"), eq(byte[].class)))
-                .thenReturn(new byte[]{4, 5, 6});
-
-        when(imageUploader.upload(any(byte[].class), anyString(), eq("image/jpeg")))
-                .thenReturn("https://s3.findyou.store/1.jpg", "https://s3.findyou.store/2.jpg");
-
-        MissingReportDetailResponseDTO dto = mock(MissingReportDetailResponseDTO.class);
-
-        ArgumentCaptor<List<String>> s3UrlsCaptor = ArgumentCaptor.forClass(List.class);
-        when(missingReportDetailStrategy.toDetailDto(eq(report), s3UrlsCaptor.capture(), eq(false)))
-                .thenReturn(dto);
-
-        // when
-        List<MissingReportDetailResponseDTO> result =
-                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(1);
-
-        // then
-        assertThat(result).hasSize(1).containsExactly(dto);
-
-        List<String> capturedUrls = s3UrlsCaptor.getValue();
-        assertThat(capturedUrls).containsExactly(
-                "https://s3.findyou.store/1.jpg",
-                "https://s3.findyou.store/2.jpg"
-        );
-
-        verify(restTemplate, times(1)).getForObject("http://example.com/1.jpg", byte[].class);
-        verify(restTemplate, times(1)).getForObject("http://example.com/2.jpg", byte[].class);
-        verify(imageUploader, times(2)).upload(any(byte[].class), anyString(), eq("image/jpeg"));
-    }
-
-    @Test
-    @DisplayName("S3 업로드/다운로드에서 예외가 발생해도 DTO는 정상 반환되고, 성공한 URL만 전달된다")
-    void getRandomMissingReportsWithS3_whenUploadFails_thenContinuePerImage() {
-        // given
-        MissingReport report = mock(MissingReport.class);
-        when(report.getId()).thenReturn(200L);
-
-        ReportImage img1 = mock(ReportImage.class);
-        ReportImage img2 = mock(ReportImage.class);
-
-        when(img1.getImageUrl()).thenReturn("http://example.com/1.jpg");
-        when(img2.getImageUrl()).thenReturn("http://example.com/2.jpg");
-        when(report.getReportImages()).thenReturn(List.of(img1, img2));
-
-        when(missingReportRepository.findByDate(any(LocalDate.class)))
-                .thenReturn(new ArrayList<>(List.of(report)));
-
-        // 1번: 다운로드 성공 -> 업로드 실패
-        when(restTemplate.getForObject("http://example.com/1.jpg", byte[].class))
-                .thenReturn(new byte[]{1, 2, 3});
-        when(imageUploader.upload(any(byte[].class), anyString(), eq("image/jpeg")))
-                .thenThrow(new FileUploadingFailedException("업로드 실패"));
-
-        // 2번: 다운로드 자체 실패
-        when(restTemplate.getForObject("http://example.com/2.jpg", byte[].class))
-                .thenThrow(new RuntimeException("다운로드 오류"));
-
-        MissingReportDetailResponseDTO dto = mock(MissingReportDetailResponseDTO.class);
-
-        ArgumentCaptor<List<String>> s3UrlsCaptor = ArgumentCaptor.forClass(List.class);
-        when(missingReportDetailStrategy.toDetailDto(eq(report), s3UrlsCaptor.capture(), eq(false)))
-                .thenReturn(dto);
-
-        // when
-        List<MissingReportDetailResponseDTO> result =
-                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(1);
-
-        // then
-        assertThat(result).hasSize(1).containsExactly(dto);
-
-        // 둘 다 실패했으니 URL은 빈 리스트
-        assertThat(s3UrlsCaptor.getValue()).isEmpty();
-
-        verify(restTemplate, times(1)).getForObject("http://example.com/1.jpg", byte[].class);
-        verify(restTemplate, times(1)).getForObject("http://example.com/2.jpg", byte[].class);
-        verify(imageUploader, times(1)).upload(any(byte[].class), anyString(), eq("image/jpeg"));
-    }
-
-    @Test
     @DisplayName("Repository 조회 날짜가 '어제'로 들어간다")
     void getRandomMissingReportsWithS3_verifyRepositoryDateIsYesterday() {
         // given
@@ -273,4 +138,118 @@ class MissingReportRetrieveWithS3ServiceImplTest {
         verify(missingReportRepository).findByDate(dateCaptor.capture());
         assertThat(dateCaptor.getValue()).isEqualTo(LocalDate.now().minusDays(1));
     }
+    @Test
+    @DisplayName("DB에 저장된 imageUrl을 그대로 DTO에 전달한다")
+    void getRandomMissingReportsWithS3_returnsStoredImageUrls() {
+        MissingReport report = mock(MissingReport.class);
+
+        ReportImage img1 = mock(ReportImage.class);
+        when(img1.getImageUrl()).thenReturn("https://cdn.findyou.store/a.jpg");
+
+        ReportImage img2 = mock(ReportImage.class);
+        when(img2.getImageUrl()).thenReturn("https://cdn.findyou.store/b.jpg");
+
+        when(report.getReportImages()).thenReturn(List.of(img1, img2));
+        when(missingReportRepository.findByDate(any()))
+                .thenReturn(List.of(report));
+
+        MissingReportDetailResponseDTO dto = mock(MissingReportDetailResponseDTO.class);
+
+        ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+        when(missingReportDetailStrategy.toDetailDto(eq(report), captor.capture(), eq(false)))
+                .thenReturn(dto);
+
+        List<MissingReportDetailResponseDTO> result =
+                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(1);
+
+        assertThat(result).hasSize(1);
+        assertThat(captor.getValue())
+                .containsExactly(
+                        "https://cdn.findyou.store/a.jpg",
+                        "https://cdn.findyou.store/b.jpg"
+                );
+    }
+    @Test
+    @DisplayName("count가 0 이하이면 최소 1개를 반환한다")
+    void getRandomMissingReportsWithS3_whenCountZeroOrNegative_thenReturnAtLeastOne() {
+        // given
+        MissingReport r1 = mock(MissingReport.class);
+        MissingReport r2 = mock(MissingReport.class);
+        MissingReport r3 = mock(MissingReport.class);
+
+        when(r1.getReportImages()).thenReturn(Collections.emptyList());
+        when(r2.getReportImages()).thenReturn(Collections.emptyList());
+        when(r3.getReportImages()).thenReturn(Collections.emptyList());
+
+        when(missingReportRepository.findByDate(any(LocalDate.class)))
+                .thenReturn(new ArrayList<>(List.of(r1, r2, r3)));
+
+        when(missingReportDetailStrategy.toDetailDto(any(MissingReport.class), anyList(), eq(false)))
+                .thenReturn(mock(MissingReportDetailResponseDTO.class));
+
+        // when
+        List<MissingReportDetailResponseDTO> resultZero =
+                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(0);
+
+        List<MissingReportDetailResponseDTO> resultNegative =
+                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(-5);
+
+        // then
+        assertThat(resultZero).hasSize(1);
+        assertThat(resultNegative).hasSize(1);
+
+        verify(missingReportRepository, times(2)).findByDate(any(LocalDate.class));
+        verify(missingReportDetailStrategy, times(2))
+                .toDetailDto(any(MissingReport.class), anyList(), eq(false));
+    }
+
+    @Test
+    @DisplayName("imageUrl에서 null/blank/중복 제거 후 DTO로 전달한다")
+    void getRandomMissingReportsWithS3_filtersNullBlankAndDistinctImageUrls() {
+        // given
+        MissingReport report = mock(MissingReport.class);
+
+        ReportImage imgNull = mock(ReportImage.class);
+        when(imgNull.getImageUrl()).thenReturn(null);
+
+        ReportImage imgBlank = mock(ReportImage.class);
+        when(imgBlank.getImageUrl()).thenReturn("   ");
+
+        ReportImage imgA1 = mock(ReportImage.class);
+        when(imgA1.getImageUrl()).thenReturn("https://cdn.findyou.store/a.jpg");
+
+        ReportImage imgA2 = mock(ReportImage.class);
+        when(imgA2.getImageUrl()).thenReturn("https://cdn.findyou.store/a.jpg");
+
+        ReportImage imgB = mock(ReportImage.class);
+        when(imgB.getImageUrl()).thenReturn("https://cdn.findyou.store/b.jpg");
+
+        when(report.getReportImages()).thenReturn(List.of(imgNull, imgBlank, imgA1, imgA2, imgB));
+
+        when(missingReportRepository.findByDate(any(LocalDate.class)))
+                .thenReturn(new ArrayList<>(List.of(report)));
+
+        MissingReportDetailResponseDTO dto = mock(MissingReportDetailResponseDTO.class);
+
+        ArgumentCaptor<List<String>> urlCaptor = ArgumentCaptor.forClass(List.class);
+        when(missingReportDetailStrategy.toDetailDto(eq(report), urlCaptor.capture(), eq(false)))
+                .thenReturn(dto);
+
+        // when
+        List<MissingReportDetailResponseDTO> result =
+                missingReportRetrieveWithS3Service.getRandomMissingReportsWithS3(1);
+
+        // then
+        assertThat(result).hasSize(1).containsExactly(dto);
+        assertThat(urlCaptor.getValue())
+                .containsExactly(
+                        "https://cdn.findyou.store/a.jpg",
+                        "https://cdn.findyou.store/b.jpg"
+                );
+
+        verify(missingReportRepository, times(1)).findByDate(any(LocalDate.class));
+        verify(missingReportDetailStrategy, times(1))
+                .toDetailDto(eq(report), anyList(), eq(false));
+    }
+
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #152

## Work Description 📝
- 파이썬 스케줄러에서 호출해서 인스타그램 홍보용 컨텐츠 자동 생성에 활용할 용도로 활용되는 API입니다. 기존 보호글 랜덤 조회 기능 말고 신고글 랜덤 조회도 필요하다는 요청이 있어  구현했습니다.

- 보호글 랜덤 조회 기능과 로직이 거의 동일하지만, s3로 업로드 하는 로직이 불필요하기에, 해당 부분만 상이합니다.

- MissingReportDetailStrategy에 공통 매핑 메서드를 추가했습니다.  (toDetailDto)

## Screenshot 📸

<img width="1751" height="1252" alt="image" src="https://github.com/user-attachments/assets/277fc5b6-9304-4a78-885d-b656e5cc6e6d" />

## Uncompleted Tasks 😅


## To Reviewers 📢
