### PR TITLE
[Fix] 품종 정보 필드 길이 수정

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/report/model/Report.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/Report.java
@@ -28,7 +28,7 @@ public abstract class Report extends BaseEntity {
     @Column(name = "id", nullable = false)
     private Long id;
 
-    @Column(name = "breed", length = 20, nullable = false)
+    @Column(name = "breed", length = 50, nullable = false)
     private String breed;
 
     @Column(name = "species", length = 100, nullable = false)

--- a/src/main/resources/db/migration/V9__alter_reports_breed_column.sql
+++ b/src/main/resources/db/migration/V9__alter_reports_breed_column.sql
@@ -1,0 +1,4 @@
+-- V9__alter_reports_breed_column.sql
+-- reports 테이블의 breed 컬럼 길이를 20에서 50으로 변경
+
+ALTER TABLE reports MODIFY COLUMN breed VARCHAR(50) NOT NULL;


### PR DESCRIPTION
## Related issue 🛠
- closed #166 

## Work Description 📝
- Report 엔티티의 breed 필드의 길이를 20 -> 50 으로 증가시켰습니다.

-> 공공데이터를 통해 전해지는 데이터 중 최대 길이 21글자의 품종 정보가 존재하여, 기존의 20글자 칼럼으로는 데이터를 정상적으로 저장할 수 없는 문제가 발생했습니다.
따라서 해당 문제를 해결하고자 품종 칼럼의 길이를 증가시키는 작업을 거쳤습니다.

## Screenshot 📸

## Uncompleted Tasks 😅

## To Reviewers 📢
